### PR TITLE
fix: improve Ctrl+C interrupt handling in chat orchestrator

### DIFF
--- a/src/kagan/chat/controller.py
+++ b/src/kagan/chat/controller.py
@@ -444,6 +444,16 @@ class ChatController:
             await self._persist_session()
         return self._restart_requested
 
+    def _append_turn(self, user_text: str, assistant_reply: str) -> None:
+        """Record a user/assistant exchange in conversation history."""
+        self._chat_history.append(("user", user_text))
+        self._rendered_messages.append(f"You: {user_text.strip()}")
+        if assistant_reply:
+            self._chat_history.append(("assistant", assistant_reply))
+            self._rendered_messages.append(f"Agent: {assistant_reply}")
+        self._chat_history = self._chat_history[-120:]
+        self._rendered_messages = self._rendered_messages[-300:]
+
     async def _persist_session(self) -> None:
         if self._chat_session_id is None or not self._persist_repl_session:
             return
@@ -1023,7 +1033,8 @@ class ChatController:
                 name="chat-prompt",
             )
             original_sigint = signal.getsignal(signal.SIGINT)
-            signal.signal(signal.SIGINT, lambda *_: prompt_task.cancel())
+            loop = asyncio.get_running_loop()
+            signal.signal(signal.SIGINT, lambda *_: loop.call_soon_threadsafe(prompt_task.cancel))
             try:
                 await prompt_task
             except asyncio.CancelledError:
@@ -1039,28 +1050,17 @@ class ChatController:
             finally:
                 signal.signal(signal.SIGINT, original_sigint)
 
-        assistant_reply = self._acp_client.finish_turn() if self._acp_client is not None else ""
+        assistant_reply = ""
+        if self._acp_client is not None:
+            with contextlib.suppress(Exception):
+                assistant_reply = self._acp_client.finish_turn()
+
+        self._append_turn(text, assistant_reply)
 
         if interrupted:
             _console.print("\n[dim]Interrupted.[/dim]")
-            # Save partial conversation state
-            self._chat_history.append(("user", text))
-            self._rendered_messages.append(f"You: {text.strip()}")
-            if assistant_reply:
-                self._chat_history.append(("assistant", assistant_reply))
-                self._rendered_messages.append(f"Agent: {assistant_reply}")
-            self._chat_history = self._chat_history[-120:]
-            self._rendered_messages = self._rendered_messages[-300:]
             await self._persist_session()
             return
-
-        self._chat_history.append(("user", text))
-        self._rendered_messages.append(f"You: {text.strip()}")
-        if assistant_reply:
-            self._chat_history.append(("assistant", assistant_reply))
-            self._rendered_messages.append(f"Agent: {assistant_reply}")
-        self._chat_history = self._chat_history[-120:]
-        self._rendered_messages = self._rendered_messages[-300:]
 
         _console.print()  # newline after streamed output
         # Re-render as markdown if the response contains rich formatting

--- a/src/kagan/chat/controller.py
+++ b/src/kagan/chat/controller.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import os
 import shutil
+import signal
 import sys
 import time
 from collections.abc import AsyncIterator, Callable
@@ -1010,14 +1011,23 @@ class ChatController:
         _console.print()
         _console.print(f"[bold]You:[/bold] {text}")
 
+        interrupted = False
         async with _turn_wave_animation(_console, WAVE_FRAMES) as stop_animation:
             if self._acp_client is not None:
                 self._acp_client.start_turn(on_first_update=stop_animation)
-            try:
-                await self._acp_conn.prompt(
+            prompt_task = asyncio.create_task(
+                self._acp_conn.prompt(
                     session_id=self._acp_session_id,
                     prompt=prompt_blocks,
-                )
+                ),
+                name="chat-prompt",
+            )
+            original_sigint = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGINT, lambda *_: prompt_task.cancel())
+            try:
+                await prompt_task
+            except asyncio.CancelledError:
+                interrupted = True
             except (acp.RequestError, TimeoutError, OSError, RuntimeError, ValueError) as exc:
                 logger.exception("Failed to send prompt to agent")
                 _console.print(f"\n[red]Agent error: {exc}[/red]")
@@ -1026,8 +1036,24 @@ class ChatController:
                 logger.exception("Unexpected failure while sending prompt to agent")
                 _console.print(f"\n[red]Agent error: {exc}[/red]")
                 return
+            finally:
+                signal.signal(signal.SIGINT, original_sigint)
 
         assistant_reply = self._acp_client.finish_turn() if self._acp_client is not None else ""
+
+        if interrupted:
+            _console.print("\n[dim]Interrupted.[/dim]")
+            # Save partial conversation state
+            self._chat_history.append(("user", text))
+            self._rendered_messages.append(f"You: {text.strip()}")
+            if assistant_reply:
+                self._chat_history.append(("assistant", assistant_reply))
+                self._rendered_messages.append(f"Agent: {assistant_reply}")
+            self._chat_history = self._chat_history[-120:]
+            self._rendered_messages = self._rendered_messages[-300:]
+            await self._persist_session()
+            return
+
         self._chat_history.append(("user", text))
         self._rendered_messages.append(f"You: {text.strip()}")
         if assistant_reply:
@@ -1063,7 +1089,7 @@ class ChatController:
         """Interactive REPL loop — runs inside spawn_agent_process context."""
         _console.print(
             "[dim]Type [bold]/help[/bold] for commands, [bold]/flow[/bold] for guided mode, "
-            "[bold]Ctrl-U[/bold] to clear input, "
+            "[bold]Ctrl-C[/bold] to interrupt, "
             "[bold]Ctrl-D[/bold] to exit.[/dim]\n"
         )
         try:
@@ -1087,6 +1113,8 @@ class ChatController:
 
                 try:
                     await self._send(stripped)
+                except KeyboardInterrupt:
+                    continue  # Safety net — SIGINT handler should handle this in _send()
                 except (acp.RequestError, TimeoutError, OSError, RuntimeError, ValueError) as exc:
                     logger.exception("Chat send failed")
                     _console.print(f"[red]Error:[/red] {exc}")

--- a/src/kagan/tui/widgets/chat.py
+++ b/src/kagan/tui/widgets/chat.py
@@ -644,14 +644,15 @@ class ChatPanel(Vertical):
             return
 
         if event.key == "ctrl+c":
-            if self._input_widget().value:
-                event.prevent_default()
-                event.stop()
-                self.action_clear_input()
-                return
             event.prevent_default()
             event.stop()
-            self.post_message(ChatPanel.InterruptRequested())
+            # Agent active → interrupt first (regardless of input text)
+            if self._runtime_status in {"thinking", "initializing", "waiting"}:
+                self.post_message(ChatPanel.InterruptRequested())
+                return
+            # Agent idle → clear input text if any
+            if self._input_widget().value:
+                self.action_clear_input()
             return
 
         if event.key == "enter":

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "kagan"
-version = "0.7.0"
+version = "0.8.1b2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- Ctrl+C now cancels the active ACP prompt via `SIGINT → task.cancel()` instead of silently clearing input text
- Partial conversation state is persisted on interrupt so context isn't lost
- TUI `ChatPanel`: Ctrl+C interrupts agent when active (`thinking`/`initializing`/`waiting`), clears input only when agent is idle
- Add `KeyboardInterrupt` safety net in the REPL loop
- Update help text: `Ctrl-C to interrupt` replaces `Ctrl-U to clear input`

## Test plan

- [x] `uv run poe fix` — lint clean
- [x] `uv run poe typecheck` — 0 errors
- [x] 699 tests pass locally (`-m "not slow and not e2e and not snapshot"`)
- [ ] CI green across Ubuntu (3.12–3.14), macOS, Windows
