### PR TITLE
refactor: minor tweaks

### DIFF
--- a/packages/web/src/components/board/agent-control.tsx
+++ b/packages/web/src/components/board/agent-control.tsx
@@ -11,7 +11,7 @@ import { useAtomValue } from "jotai";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api/client";
 import { sseConnectedAtom } from "@/lib/atoms/connection";
-import { cn } from "@/lib/utils";
+import { cn, asBool, normalizeLauncher, quoteShell } from "@/lib/utils";
 import {
     openInEditor,
     launcherDisplayName,
@@ -28,32 +28,6 @@ import {
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 
-const LAUNCHER_BACKENDS: readonly LauncherBackend[] = [
-    "tmux",
-    "nvim",
-    "vscode",
-    "cursor",
-    "windsurf",
-    "kiro",
-    "antigravity",
-];
-
-function asBool(value: string | undefined, fallback: boolean): boolean {
-    if (value === undefined) return fallback;
-    return !["0", "false", "no", "off"].includes(value.trim().toLowerCase());
-}
-
-function normalizeLauncher(value: string | null | undefined): LauncherBackend {
-    if (!value) return "vscode";
-    const normalized = value.trim().toLowerCase();
-    return LAUNCHER_BACKENDS.includes(normalized as LauncherBackend)
-        ? (normalized as LauncherBackend)
-        : "vscode";
-}
-
-function quoteShell(value: string): string {
-    return `"${value.replace(/["\\$`]/g, "\\$&")}"`;
-}
 
 function tmuxSessionName(sessionId: string): string {
     return `kagan-${sessionId.replaceAll(":", "-")}`;

--- a/packages/web/src/components/settings/settings-panel.tsx
+++ b/packages/web/src/components/settings/settings-panel.tsx
@@ -17,6 +17,7 @@ import {
   FieldSeparator,
   FieldSet,
 } from '@/components/ui/field';
+import { asBool } from '@/lib/utils';
 import { AppearanceSettings } from './sections/appearance-settings';
 import { WorkflowSettings } from './sections/workflow-settings';
 import { WorkspaceSettings } from './sections/workspace-settings';
@@ -70,11 +71,6 @@ export const DEFAULT_FORM: SettingsFormState = {
   planning_depth: 'always',
   auto_confirm_single_tasks: false,
 };
-
-export function asBool(value: string | undefined, fallback: boolean): boolean {
-  if (value === undefined) return fallback;
-  return !['0', 'false', 'no', 'off'].includes(value.trim().toLowerCase());
-}
 
 export interface ToggleRowProps {
   title: string;

--- a/packages/web/src/lib/__tests__/utils.test.ts
+++ b/packages/web/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { asBool, normalizeLauncher, quoteShell } from "../utils";
+
+describe("asBool", () => {
+  it("returns fallback for undefined", () => {
+    expect(asBool(undefined, true)).toBe(true);
+    expect(asBool(undefined, false)).toBe(false);
+  });
+
+  it("parses true values", () => {
+    expect(asBool("true", false)).toBe(true);
+    expect(asBool("1", false)).toBe(true);
+    expect(asBool("yes", false)).toBe(true);
+    expect(asBool("on", false)).toBe(true);
+  });
+
+  it("returns false for falsy strings", () => {
+    expect(asBool("false", true)).toBe(false);
+    expect(asBool("0", true)).toBe(false);
+    expect(asBool("no", true)).toBe(false);
+    expect(asBool("off", true)).toBe(false);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(asBool("FALSE", true)).toBe(false);
+    expect(asBool(" False ", true)).toBe(false);
+    expect(asBool("  NO  ", true)).toBe(false);
+  });
+
+  it("treats unrecognized strings as truthy", () => {
+    expect(asBool("", false)).toBe(true);
+    expect(asBool("anything", false)).toBe(true);
+  });
+});
+
+describe("normalizeLauncher", () => {
+  it("returns vscode for null/undefined/empty", () => {
+    expect(normalizeLauncher(null)).toBe("vscode");
+    expect(normalizeLauncher(undefined)).toBe("vscode");
+    expect(normalizeLauncher("")).toBe("vscode");
+  });
+
+  it("normalizes known backends", () => {
+    expect(normalizeLauncher("tmux")).toBe("tmux");
+    expect(normalizeLauncher("nvim")).toBe("nvim");
+    expect(normalizeLauncher("cursor")).toBe("cursor");
+    expect(normalizeLauncher("windsurf")).toBe("windsurf");
+    expect(normalizeLauncher("kiro")).toBe("kiro");
+    expect(normalizeLauncher("antigravity")).toBe("antigravity");
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(normalizeLauncher("VSCODE")).toBe("vscode");
+    expect(normalizeLauncher(" Cursor ")).toBe("cursor");
+  });
+
+  it("falls back to vscode for unknown backends", () => {
+    expect(normalizeLauncher("emacs")).toBe("vscode");
+    expect(normalizeLauncher("sublime")).toBe("vscode");
+  });
+});
+
+describe("quoteShell", () => {
+  it("wraps value in double quotes", () => {
+    expect(quoteShell("hello")).toBe('"hello"');
+  });
+
+  it("escapes double quotes", () => {
+    expect(quoteShell('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it("escapes backslashes", () => {
+    expect(quoteShell("path\\to")).toBe('"path\\\\to"');
+  });
+
+  it("escapes dollar signs", () => {
+    expect(quoteShell("$HOME")).toBe('"\\$HOME"');
+  });
+
+  it("escapes backticks", () => {
+    expect(quoteShell("`cmd`")).toBe('"\\`cmd\\`"');
+  });
+
+  it("leaves safe characters untouched", () => {
+    expect(quoteShell("/usr/local/bin")).toBe('"/usr/local/bin"');
+  });
+});

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -1,6 +1,34 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import type { LauncherBackend } from '@/lib/utils/editor-links';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export const LAUNCHER_BACKENDS: readonly LauncherBackend[] = [
+  'tmux',
+  'nvim',
+  'vscode',
+  'cursor',
+  'windsurf',
+  'kiro',
+  'antigravity',
+];
+
+export function asBool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  return !['0', 'false', 'no', 'off'].includes(value.trim().toLowerCase());
+}
+
+export function normalizeLauncher(value: string | null | undefined): LauncherBackend {
+  if (!value) return 'vscode';
+  const normalized = value.trim().toLowerCase();
+  return LAUNCHER_BACKENDS.includes(normalized as LauncherBackend)
+    ? (normalized as LauncherBackend)
+    : 'vscode';
+}
+
+export function quoteShell(value: string): string {
+  return `"${value.replace(/["\\$`]/g, '\\$&')}"`;
 }

--- a/packages/web/src/pages/task-detail-page.tsx
+++ b/packages/web/src/pages/task-detail-page.tsx
@@ -30,7 +30,6 @@ import { useTaskEvents } from "@/lib/hooks/use-task-events";
 import {
     openInEditor,
     launcherDisplayName,
-    type LauncherBackend,
 } from "@/lib/utils/editor-links";
 import {
     ActionEmptyState,
@@ -62,30 +61,10 @@ import { EditTaskDialog } from "@/components/board/edit-task-dialog";
 import { TaskDeleteDialog } from "@/components/board/task-delete-dialog";
 import { TaskSidebar } from "@/components/board/task-sidebar";
 import { isEditableTarget, hasOpenOverlay } from "@/lib/utils/dom";
+import { normalizeLauncher, quoteShell } from "@/lib/utils";
 
 export type WorkspaceTab = "overview" | "changes" | "review";
 
-const LAUNCHER_BACKENDS: readonly LauncherBackend[] = [
-    "tmux",
-    "nvim",
-    "vscode",
-    "cursor",
-    "windsurf",
-    "kiro",
-    "antigravity",
-];
-
-function normalizeLauncher(value: string | null | undefined): LauncherBackend {
-    if (!value) return "vscode";
-    const normalized = value.trim().toLowerCase();
-    return LAUNCHER_BACKENDS.includes(normalized as LauncherBackend)
-        ? (normalized as LauncherBackend)
-        : "vscode";
-}
-
-function quoteShell(value: string): string {
-    return `"${value.replace(/["\\$`]/g, "\\$&")}"`;
-}
 
 function tmuxSessionName(sessionId: string): string {
     return `kagan-${sessionId.replaceAll(":", "-")}`;

--- a/src/kagan/mcp/toolsets/sessions.py
+++ b/src/kagan/mcp/toolsets/sessions.py
@@ -1,9 +1,9 @@
 """kagan.mcp.toolsets.sessions — Session lifecycle MCP tools."""
 
-import contextlib
 from enum import StrEnum
 from typing import Any, TypedDict, cast
 
+from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 
 from kagan.core import resolve_default_agent_backend, resolve_launcher
@@ -172,8 +172,10 @@ async def _run_summary(ctx: Context, task_ids: list[str] | None = None) -> dict:
     for task in tasks:
         session = await _get_latest_session(app.client, task.id)
         ws = None
-        with contextlib.suppress(Exception):
+        try:
             ws = await app.client.worktrees.get(task.id)
+        except (KaganError, OSError) as exc:
+            logger.debug("Failed to fetch worktree for task {}: {}", task.id, exc)
         row: dict[str, Any] = {
             "task_id": task.id,
             "status": task.status.value,

--- a/src/kagan/mcp/toolsets/tasks.py
+++ b/src/kagan/mcp/toolsets/tasks.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 from typing import Any, TypedDict
 
+from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 
 from kagan.core import Priority, TaskStatus, parse_priority
@@ -145,10 +146,12 @@ async def _task_get(ctx: Context, task_id: str | None = None) -> dict:
         result["session_id"] = app.bound_session_id
 
     # Include worktree path so agents know where task files live
-    with contextlib.suppress(Exception):
+    try:
         ws = await app.client.worktrees.get(resolved_task_id)
         if ws is not None:
             result["worktree_path"] = ws.worktree_path
+    except (KaganError, OSError) as exc:
+        logger.debug("Failed to fetch worktree for task {}: {}", resolved_task_id, exc)
 
     try:
         all_tasks = await app.client.tasks.list()

--- a/src/kagan/server/_helpers.py
+++ b/src/kagan/server/_helpers.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
+from pydantic import BaseModel, ValidationError
 from starlette.responses import JSONResponse
 
 from kagan.core import TaskStatus
@@ -33,6 +34,14 @@ def _err(msg: str, status: int = 400, *, error_code: str | None = None) -> JSONR
     return JSONResponse(payload, status_code=status)
 
 
+async def parse_body[T: BaseModel](request: Any, model: type[T]) -> T:
+    """Parse and validate a JSON request body against a Pydantic model."""
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise ValueError("Request body must be a JSON object")
+    return model.model_validate(payload)
+
+
 def _error_response(exc: Exception) -> JSONResponse:
     error_code = cast("str | None", getattr(exc, "code", None))
     if isinstance(exc, NotFoundError):
@@ -48,6 +57,9 @@ def _error_response(exc: Exception) -> JSONResponse:
         logger.debug("Route handler missing field: {}", exc)
         field = exc.args[0] if exc.args else "unknown"
         return _err(f"Missing field: {field}", status=400, error_code=error_code)
+    if isinstance(exc, ValidationError):
+        logger.debug("Route handler validation error: {}", exc)
+        return _err(str(exc), status=422, error_code=error_code)
     if isinstance(exc, ValueError | TypeError):
         logger.debug("Route handler validation error: {}", exc)
         return _err(str(exc), status=400, error_code=error_code)

--- a/src/kagan/server/_routes.py
+++ b/src/kagan/server/_routes.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+
+from loguru import logger
 
 from kagan.core import (
     TaskStatus,
@@ -21,10 +22,21 @@ from kagan.server._helpers import (
     _ok,
     _require_access,
     handle_errors,
+    parse_body,
     require_context,
     task_to_wire_dict,
 )
 from kagan.server._sse import _sse_event_generator, sse_response
+from kagan.server.requests import (
+    AddRepoRequest,
+    CreateProjectRequest,
+    CreateTaskRequest,
+    FollowUpRequest,
+    ReviewDecideRequest,
+    RunTaskRequest,
+    UpdateTaskRequest,
+    UpdateTaskStatusRequest,
+)
 from kagan.server.responses import EventResponse, ProjectResponse, RepositoryResponse
 
 if TYPE_CHECKING:
@@ -76,13 +88,6 @@ def _repo_dict(repo: Any, *, selected: bool = False) -> dict[str, Any]:
 
 def _event_dict(event: Any) -> dict[str, Any]:
     return EventResponse.model_validate(event).model_dump(mode="json")
-
-
-async def _body(request: Request) -> dict[str, Any]:
-    payload = await request.json()
-    if not isinstance(payload, dict):
-        raise ValueError("Request body must be a JSON object")
-    return cast("dict[str, Any]", payload)
 
 
 def _manual_review_required(task_id: str) -> JSONResponse:
@@ -152,19 +157,15 @@ def register_routes(mcp: FastMCP) -> None:
         )
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
-        payload = await _body(request)
-        acceptance_criteria = payload.get("acceptance_criteria")
-        if acceptance_criteria is not None and not isinstance(acceptance_criteria, list):
-            raise ValueError("acceptance_criteria must be a list of strings")
-
+        body = await parse_body(request, CreateTaskRequest)
         task = await ctx.client.tasks.create(
-            cast("str", payload["title"]),
-            description=cast("str", payload.get("description", "")),
-            priority=parse_priority(cast("str | int | None", payload.get("priority"))),
-            base_branch=cast("str | None", payload.get("base_branch")),
-            acceptance_criteria=cast("list[str] | None", acceptance_criteria),
-            agent_backend=cast("str | None", payload.get("agent_backend")),
-            launcher=cast("str | None", payload.get("launcher")),
+            body.title,
+            description=body.description,
+            priority=parse_priority(body.priority),
+            base_branch=body.base_branch,
+            acceptance_criteria=body.acceptance_criteria,
+            agent_backend=body.agent_backend,
+            launcher=body.launcher,
         )
         runtime = await ctx.client.tasks.runtime_summary(task.id)
         return _ok(task_to_wire_dict(task, runtime=runtime))
@@ -194,29 +195,13 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         task_id = cast("str", request.path_params["task_id"])
-        payload = await _body(request)
-
+        body = await parse_body(request, UpdateTaskRequest)
         update_args: dict[str, Any] = {}
-        if "title" in payload:
-            update_args["title"] = payload["title"]
-        if "description" in payload:
-            update_args["description"] = payload["description"]
-        if "priority" in payload:
-            update_args["priority"] = parse_priority(
-                cast("str | int | None", payload.get("priority"))
-            )
-        if "base_branch" in payload:
-            update_args["base_branch"] = payload["base_branch"]
-        if "acceptance_criteria" in payload:
-            criteria = payload["acceptance_criteria"]
-            if criteria is not None and not isinstance(criteria, list):
-                raise ValueError("acceptance_criteria must be a list of strings")
-            update_args["acceptance_criteria"] = criteria
-        if "agent_backend" in payload:
-            update_args["agent_backend"] = payload["agent_backend"]
-        if "launcher" in payload:
-            update_args["launcher"] = payload["launcher"]
-
+        for field in body.model_fields_set:
+            value = getattr(body, field)
+            if field == "priority":
+                value = parse_priority(value)
+            update_args[field] = value
         task = await ctx.client.tasks.update(task_id, **update_args)
         runtime = await ctx.client.tasks.runtime_summary(task_id)
         return _ok(task_to_wire_dict(task, runtime=runtime))
@@ -242,9 +227,8 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         task_id = cast("str", request.path_params["task_id"])
-        payload = await _body(request)
-        status_value = cast("str", payload["status"])
-        task = await ctx.client.tasks.set_status(task_id, TaskStatus(status_value))
+        body = await parse_body(request, UpdateTaskStatusRequest)
+        task = await ctx.client.tasks.set_status(task_id, TaskStatus(body.status))
         runtime = await ctx.client.tasks.runtime_summary(task_id)
         return _ok(task_to_wire_dict(task, runtime=runtime))
 
@@ -258,24 +242,21 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         task_id = cast("str", request.path_params["task_id"])
-        payload = await _body(request)
-        agent_backend = cast("str", payload.get("agent_backend", ""))
+        body = await parse_body(request, RunTaskRequest)
+        agent_backend = body.agent_backend
         settings = await ctx.client.settings.get()
         if not agent_backend:
             agent_backend = settings.get("default_agent_backend", "claude-code")
-        persona = cast("str | None", payload.get("persona"))
         launcher = None
         ide = None
-        payload_launcher = cast("str | None", payload.get("launcher"))
-        if isinstance(payload_launcher, str) and payload_launcher.strip():
-            launcher_input = payload_launcher.strip().lower()
-            launcher, ide = resolve_launcher(launcher_input)
+        if body.launcher and body.launcher.strip():
+            launcher, ide = resolve_launcher(body.launcher.strip().lower())
         await ctx.client.tasks.run(
             task_id,
             agent_backend=agent_backend,
             launcher=launcher,
             ide=ide,
-            persona=persona,
+            persona=body.persona,
         )
         runtime = await ctx.client.tasks.runtime_summary(task_id)
         task = await ctx.client.tasks.get(task_id)
@@ -391,8 +372,8 @@ def register_routes(mcp: FastMCP) -> None:
         )
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
-        payload = await _body(request)
-        project = await ctx.client.projects.create(cast("str", payload["name"]))
+        body = await parse_body(request, CreateProjectRequest)
+        project = await ctx.client.projects.create(body.name)
         return _ok(_project_dict(project, active=project.id == ctx.client.active_project_id))
 
     @mcp.custom_route("/api/projects/{project_id}/activate", methods=["POST"])
@@ -441,9 +422,8 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         project_id = cast("str", request.path_params["project_id"])
-        payload = await _body(request)
-        path = cast("str", payload["path"])
-        repo = await ctx.client.projects.add_repo(project_id, path)
+        body = await parse_body(request, AddRepoRequest)
+        repo = await ctx.client.projects.add_repo(project_id, body.path)
         return _ok(_repo_dict(repo))
 
     @mcp.custom_route("/api/projects/{project_id}/repos/{repo_id}/select", methods=["POST"])
@@ -488,8 +468,8 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         task_id = cast("str", request.path_params["task_id"])
-        payload = await _body(request)
-        action = cast("str", payload["action"]).lower()
+        body = await parse_body(request, ReviewDecideRequest)
+        action = body.action.lower()
 
         if action in {"approve", "merge"}:
             task = await ctx.client.tasks.get(task_id)
@@ -501,7 +481,7 @@ def register_routes(mcp: FastMCP) -> None:
             task = await ctx.client.reviews.approve(task_id)
             return _ok({"task": task_to_wire_dict(task), "action": action})
         if action == "reject":
-            feedback = cast("str | None", payload.get("feedback"))
+            feedback = body.feedback
             if not feedback:
                 raise ValueError("feedback is required for reject action")
             task = await ctx.client.reviews.reject(task_id, feedback=feedback)
@@ -539,7 +519,9 @@ def register_routes(mcp: FastMCP) -> None:
         )
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
-        payload = await _body(request)
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Request body must be a JSON object")
         updates = {str(key): "" if value is None else str(value) for key, value in payload.items()}
         await ctx.client.settings.set(updates)
         return _ok(await ctx.client.settings.get())
@@ -744,20 +726,19 @@ def register_routes(mcp: FastMCP) -> None:
         if forbidden is not None:
             return cast("JSONResponse", forbidden)
         task_id = cast("str", request.path_params["task_id"])
-        payload = await _body(request)
-        text = cast("str", payload.get("text", "")).strip()
-        if not text:
-            raise ValueError("text is required")
+        body = await parse_body(request, FollowUpRequest)
 
         from kagan.core import resolve_default_agent_backend
 
         # Best-effort cancel current run
-        with contextlib.suppress(Exception):
+        try:
             await ctx.client.tasks.cancel(task_id)
+        except Exception as exc:
+            logger.debug("Failed to cancel current run for task {}: {}", task_id, exc)
 
         task = await ctx.client.tasks.get(task_id)
         current_desc = (getattr(task, "description", "") or "").strip()
-        follow_up = f"User follow-up:\n{text}"
+        follow_up = f"User follow-up:\n{body.text}"
         updated_desc = f"{current_desc}\n\n{follow_up}" if current_desc else follow_up
         task = await ctx.client.tasks.update(task_id, description=updated_desc)
 

--- a/src/kagan/server/requests.py
+++ b/src/kagan/server/requests.py
@@ -9,42 +9,35 @@ from __future__ import annotations
 from pydantic import BaseModel, field_validator
 
 
-class CreateTaskRequest(BaseModel):
+class _CriteriaMixin(BaseModel):
+    acceptance_criteria: list[str] | None = None
+
+    @field_validator("acceptance_criteria", mode="before")
+    @classmethod
+    def _validate_criteria(cls, v: object) -> list[str] | None:
+        if v is None:
+            return None
+        if not isinstance(v, list):
+            raise ValueError("acceptance_criteria must be a list of strings")
+        return v
+
+
+class CreateTaskRequest(_CriteriaMixin):
     title: str
     description: str = ""
     priority: str | int | None = None
     base_branch: str | None = None
-    acceptance_criteria: list[str] | None = None
     agent_backend: str | None = None
     launcher: str | None = None
 
-    @field_validator("acceptance_criteria", mode="before")
-    @classmethod
-    def _validate_criteria(cls, v: object) -> list[str] | None:
-        if v is None:
-            return None
-        if not isinstance(v, list):
-            raise ValueError("acceptance_criteria must be a list of strings")
-        return v
 
-
-class UpdateTaskRequest(BaseModel):
+class UpdateTaskRequest(_CriteriaMixin):
     title: str | None = None
     description: str | None = None
     priority: str | int | None = None
     base_branch: str | None = None
-    acceptance_criteria: list[str] | None = None
     agent_backend: str | None = None
     launcher: str | None = None
-
-    @field_validator("acceptance_criteria", mode="before")
-    @classmethod
-    def _validate_criteria(cls, v: object) -> list[str] | None:
-        if v is None:
-            return None
-        if not isinstance(v, list):
-            raise ValueError("acceptance_criteria must be a list of strings")
-        return v
 
 
 class UpdateTaskStatusRequest(BaseModel):
@@ -52,7 +45,7 @@ class UpdateTaskStatusRequest(BaseModel):
 
 
 class RunTaskRequest(BaseModel):
-    agent_backend: str = ""
+    agent_backend: str | None = None
     persona: str | None = None
     launcher: str | None = None
 
@@ -76,6 +69,9 @@ class FollowUpRequest(BaseModel):
     @field_validator("text", mode="before")
     @classmethod
     def _strip_text(cls, v: object) -> str:
-        if not isinstance(v, str) or not v.strip():
-            raise ValueError("text is required")
-        return v.strip()
+        if not isinstance(v, str):
+            raise TypeError("text must be a string")
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("text must not be empty")
+        return stripped

--- a/src/kagan/server/requests.py
+++ b/src/kagan/server/requests.py
@@ -1,0 +1,81 @@
+"""Pydantic request models — validated input for mutating API routes.
+
+Each model declares exactly the fields that a route accepts.
+Use ``parse_body(request, Model)`` from ``_helpers`` to validate.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+
+class CreateTaskRequest(BaseModel):
+    title: str
+    description: str = ""
+    priority: str | int | None = None
+    base_branch: str | None = None
+    acceptance_criteria: list[str] | None = None
+    agent_backend: str | None = None
+    launcher: str | None = None
+
+    @field_validator("acceptance_criteria", mode="before")
+    @classmethod
+    def _validate_criteria(cls, v: object) -> list[str] | None:
+        if v is None:
+            return None
+        if not isinstance(v, list):
+            raise ValueError("acceptance_criteria must be a list of strings")
+        return v
+
+
+class UpdateTaskRequest(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    priority: str | int | None = None
+    base_branch: str | None = None
+    acceptance_criteria: list[str] | None = None
+    agent_backend: str | None = None
+    launcher: str | None = None
+
+    @field_validator("acceptance_criteria", mode="before")
+    @classmethod
+    def _validate_criteria(cls, v: object) -> list[str] | None:
+        if v is None:
+            return None
+        if not isinstance(v, list):
+            raise ValueError("acceptance_criteria must be a list of strings")
+        return v
+
+
+class UpdateTaskStatusRequest(BaseModel):
+    status: str
+
+
+class RunTaskRequest(BaseModel):
+    agent_backend: str = ""
+    persona: str | None = None
+    launcher: str | None = None
+
+
+class ReviewDecideRequest(BaseModel):
+    action: str
+    feedback: str | None = None
+
+
+class CreateProjectRequest(BaseModel):
+    name: str
+
+
+class AddRepoRequest(BaseModel):
+    path: str
+
+
+class FollowUpRequest(BaseModel):
+    text: str
+
+    @field_validator("text", mode="before")
+    @classmethod
+    def _strip_text(cls, v: object) -> str:
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("text is required")
+        return v.strip()

--- a/src/kagan/tui/screens/kanban.py
+++ b/src/kagan/tui/screens/kanban.py
@@ -1144,7 +1144,10 @@ class KanbanScreen(Screen[None]):
         if not skip_instructions:
             result = await self.app.push_screen_wait(
                 AttachedInstructionsModal(
-                    task.id, task.title, backend, prompt_path,
+                    task.id,
+                    task.title,
+                    backend,
+                    prompt_path,
                     taking_over=taking_over,
                 )
             )

--- a/src/kagan/tui/screens/task_editor_modal.py
+++ b/src/kagan/tui/screens/task_editor_modal.py
@@ -1,6 +1,6 @@
-import contextlib
 from typing import TYPE_CHECKING, cast
 
+from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.screen import ModalScreen
@@ -132,7 +132,7 @@ class TaskEditorModal(ModalScreen[None]):
         if values is None:
             return
         acceptance_criteria = editor.acceptance_criteria()
-        with contextlib.suppress(Exception):  # quality-allow-broad-except
+        try:  # quality-allow-broad-except
             await self.kagan_app.core.tasks.update(
                 self._editing_task.id,
                 title=values.title,
@@ -143,6 +143,8 @@ class TaskEditorModal(ModalScreen[None]):
                 launcher=values.launcher,
                 acceptance_criteria=acceptance_criteria,
             )
+        except Exception as exc:
+            logger.debug("Auto-save failed for task {}: {}", self._editing_task.id, exc)
 
     def action_finish(self) -> None:
         self.query_one(TaskEditor).submit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,6 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         _kagan_test_root = None
 
 
-from tests.helpers.fixtures import board, git_board  # noqa: E402
+from tests.helpers.fixtures import board, board_with_task, git_board  # noqa: E402
 
-__all__ = ["board", "git_board"]
+__all__ = ["board", "board_with_task", "git_board"]

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -15,6 +15,16 @@ async def board(tmp_path: Path) -> KaganDriver:
 
 
 @pytest.fixture
+async def board_with_task(tmp_path: Path) -> KaganDriver:
+    driver = await KaganDriver.boot(tmp_path)
+    await driver.create_project("Test Project")
+    await driver.settings_update({"ui.tui_tutorial_seen": "true"})
+    await driver.create_task("Test Task")
+    yield driver  # type: ignore[misc]
+    await driver.teardown()
+
+
+@pytest.fixture
 async def git_board(tmp_path: Path) -> KaganDriver:
     repo_path = tmp_path / "repo"
     await make_git_repo(repo_path, base_branch="main")

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -261,9 +261,9 @@ async def test_missing_fields_return_error_envelopes(monkeypatch: pytest.MonkeyP
     create = get_http_endpoint(mcp, "/api/tasks", "POST")
     create_resp = await create(make_request("POST", "/api/tasks", body={"description": "x"}))
     create_payload = json_body(create_resp)
-    assert cast("Any", create_resp).status_code == 400
+    assert cast("Any", create_resp).status_code == 422
     assert create_payload["ok"] is False
-    assert create_payload["error"] == "Missing field: title"
+    assert "title" in create_payload["error"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/tui/test_chat_modes.py
+++ b/tests/tui/test_chat_modes.py
@@ -4,21 +4,12 @@ from tests.helpers.driver import KaganDriver
 pytestmark = [pytest.mark.tui, pytest.mark.smoke]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Chat Modes Project")
-    await driver.create_task("Chat task")
-    yield driver
-    await driver.teardown()
-
-
-async def test_ctrl_o_opens_chat_overlay_docked(board: KaganDriver) -> None:
+async def test_ctrl_o_opens_chat_overlay_docked(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -34,12 +25,12 @@ async def test_ctrl_o_opens_chat_overlay_docked(board: KaganDriver) -> None:
         assert "Orchestrator" in str(title.content)
 
 
-async def test_ctrl_p_opens_command_palette(board: KaganDriver) -> None:
+async def test_ctrl_p_opens_command_palette(board_with_task: KaganDriver) -> None:
     from textual.command import CommandPalette
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -50,12 +41,12 @@ async def test_ctrl_p_opens_command_palette(board: KaganDriver) -> None:
         assert isinstance(app.screen, CommandPalette)
 
 
-async def test_ctrl_p_opens_chat_fullscreen(board: KaganDriver) -> None:
+async def test_ctrl_p_opens_chat_fullscreen(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -70,12 +61,12 @@ async def test_ctrl_p_opens_chat_fullscreen(board: KaganDriver) -> None:
         assert "Orchestrator" in str(title.content)
 
 
-async def test_fullscreen_toggle_preserves_session(board: KaganDriver) -> None:
+async def test_fullscreen_toggle_preserves_session(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")

--- a/tests/tui/test_settings_modal.py
+++ b/tests/tui/test_settings_modal.py
@@ -4,14 +4,6 @@ from tests.helpers.driver import KaganDriver
 pytestmark = [pytest.mark.tui, pytest.mark.smoke]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Settings Project")
-    yield driver
-    await driver.teardown()
-
-
 async def test_comma_opens_settings_modal_and_saves(board: KaganDriver) -> None:
     from textual.widgets import Input, Select, Switch
 

--- a/tests/tui/test_task_authoring.py
+++ b/tests/tui/test_task_authoring.py
@@ -6,19 +6,10 @@ from textual.widgets import Input, Select, TextArea
 pytestmark = [pytest.mark.tui, pytest.mark.smoke]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Authoring Project")
-    await driver.create_task("Existing task")
-    yield driver
-    await driver.teardown()
-
-
-async def test_n_opens_task_creation_form(board: KaganDriver) -> None:
+async def test_n_opens_task_creation_form(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -28,10 +19,10 @@ async def test_n_opens_task_creation_form(board: KaganDriver) -> None:
         assert app.screen.id == "task-editor-modal"
 
 
-async def test_save_in_task_form_creates_new_backlog_task(board: KaganDriver) -> None:
+async def test_save_in_task_form_creates_new_backlog_task(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -41,16 +32,16 @@ async def test_save_in_task_form_creates_new_backlog_task(board: KaganDriver) ->
         await pilot.press("A", "u", "t", "h", "o", "r", "e", "d")
         await pilot.press("ctrl+s")
         await pilot.pause()
-    results = await board.search_tasks("Authored")
+    results = await board_with_task.search_tasks("Authored")
     assert len(results) == 1
 
 
 async def test_task_form_stays_scrollable_when_advanced_options_expand(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test(size=(90, 20)) as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -70,11 +61,11 @@ async def test_task_form_stays_scrollable_when_advanced_options_expand(
 
 
 async def test_task_form_scroll_action_moves_view_when_advanced_expanded(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test(size=(90, 20)) as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -93,11 +84,11 @@ async def test_task_form_scroll_action_moves_view_when_advanced_expanded(
 
 
 async def test_toggling_advanced_brings_acceptance_criteria_into_view(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test(size=(90, 20)) as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -117,10 +108,10 @@ async def test_toggling_advanced_brings_acceptance_criteria_into_view(
         assert form.scroll_y > initial_scroll
 
 
-async def test_task_form_saves_attached_launcher_override(board: KaganDriver) -> None:
+async def test_task_form_saves_attached_launcher_override(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -136,7 +127,7 @@ async def test_task_form_saves_attached_launcher_override(board: KaganDriver) ->
         await pilot.press("ctrl+s")
         await pilot.pause()
 
-    results = await board.search_tasks("Launcher")
+    results = await board_with_task.search_tasks("Launcher")
     assert len(results) == 1
-    saved = await board.get_task(results[0].id)
+    saved = await board_with_task.get_task(results[0].id)
     assert saved.launcher == "vscode"

--- a/tests/tui/test_task_output.py
+++ b/tests/tui/test_task_output.py
@@ -9,15 +9,6 @@ if TYPE_CHECKING:
     from kagan.tui.screens.task_screen import TaskScreen
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Output Project")
-    await driver.create_task("Detached task")
-    yield driver
-    await driver.teardown()
-
-
 async def _enter_project(pilot) -> None:
     await pilot.pause()
     await pilot.press("enter")
@@ -40,13 +31,13 @@ async def _open_task_screen(pilot) -> None:
     await pilot.pause()
 
 
-async def test_enter_on_detached_task_opens_task_screen(board: KaganDriver) -> None:
+async def test_enter_on_detached_task_opens_task_screen(board_with_task: KaganDriver) -> None:
     from textual.widgets import TabbedContent
 
     from kagan.tui import KaganApp
     from kagan.tui.widgets.task_inspector import TaskInspector
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _enter_project(pilot)
         await _open_inspector(pilot)
@@ -61,13 +52,13 @@ async def test_enter_on_detached_task_opens_task_screen(board: KaganDriver) -> N
         assert tabs.active == "detail"
 
 
-async def test_task_screen_shows_action_hint_footer(board: KaganDriver) -> None:
+async def test_task_screen_shows_action_hint_footer(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
     from kagan.tui.widgets.task_action_bar import TaskActionBar
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
 
@@ -80,11 +71,13 @@ async def test_task_screen_shows_action_hint_footer(board: KaganDriver) -> None:
         assert "back" in hint_text
 
 
-async def test_enter_requires_open_inspector_before_task_screen(board: KaganDriver) -> None:
+async def test_enter_requires_open_inspector_before_task_screen(
+    board_with_task: KaganDriver,
+) -> None:
     from kagan.tui import KaganApp
     from kagan.tui.widgets.task_inspector import TaskInspector
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _enter_project(pilot)
 
@@ -102,10 +95,10 @@ async def test_enter_requires_open_inspector_before_task_screen(board: KaganDriv
         assert app.screen.id == "task-screen"
 
 
-async def test_escape_from_task_screen_returns_to_kanban(board: KaganDriver) -> None:
+async def test_escape_from_task_screen_returns_to_kanban(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("escape")
@@ -113,12 +106,12 @@ async def test_escape_from_task_screen_returns_to_kanban(board: KaganDriver) -> 
         assert app.screen.id == "kanban-screen"
 
 
-async def test_enter_starts_and_ctrl_c_stops_run_indicator(board: KaganDriver) -> None:
+async def test_enter_starts_and_ctrl_c_stops_run_indicator(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("enter")
@@ -130,13 +123,13 @@ async def test_enter_starts_and_ctrl_c_stops_run_indicator(board: KaganDriver) -
         assert "Stopped" in status_text or status_text == "Ready | BACKLOG"
 
 
-async def test_ctrl_o_on_detached_task_opens_docked_task_chat(board: KaganDriver) -> None:
+async def test_ctrl_o_on_detached_task_opens_docked_task_chat(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
     from kagan.tui.widgets.chat import ChatPanel
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("ctrl+i")
@@ -154,7 +147,7 @@ async def test_ctrl_o_on_detached_task_opens_docked_task_chat(board: KaganDriver
 
 
 async def test_ctrl_p_on_detached_task_opens_fullscreen_task_chat(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from textual.containers import Vertical
     from textual.widgets import Static
@@ -163,7 +156,7 @@ async def test_ctrl_p_on_detached_task_opens_fullscreen_task_chat(
     from kagan.tui.widgets.chat import ChatPanel
     from kagan.tui.widgets.header import KaganHeader
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("ctrl+shift+t")
@@ -181,12 +174,14 @@ async def test_ctrl_p_on_detached_task_opens_fullscreen_task_chat(
         assert panel.parent is root
 
 
-async def test_enter_in_task_chat_submits_follow_up_and_restarts_agent(board: KaganDriver) -> None:
+async def test_enter_in_task_chat_submits_follow_up_and_restarts_agent(
+    board_with_task: KaganDriver,
+) -> None:
     from textual.widgets import Input, Static, TabbedContent
 
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("ctrl+shift+t")
@@ -209,13 +204,13 @@ async def test_enter_in_task_chat_submits_follow_up_and_restarts_agent(board: Ka
         assert tabs.active == active_before_send
 
 
-async def test_tab_switch_does_not_revert_to_previous_tab(board: KaganDriver) -> None:
+async def test_tab_switch_does_not_revert_to_previous_tab(board_with_task: KaganDriver) -> None:
     from textual.widgets import TabbedContent
 
     from kagan.tui import KaganApp
     from kagan.tui.widgets.diff import DiffFileTree
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
 
@@ -235,7 +230,7 @@ async def test_tab_switch_does_not_revert_to_previous_tab(board: KaganDriver) ->
 
 
 async def test_task_chat_restart_failure_surfaces_error_state(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from textual.widgets import Input, Static
@@ -254,7 +249,7 @@ async def test_task_chat_restart_failure_surfaces_error_state(
         fake_start_or_attach_session,
     )
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
         await pilot.press("ctrl+shift+t")
@@ -286,14 +281,14 @@ async def test_task_chat_restart_failure_surfaces_error_state(
 
 
 async def test_ctrl_o_on_running_detached_task_keeps_task_screen_visible(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from textual.widgets import Label
 
     from kagan.tui import KaganApp
     from kagan.tui.widgets.chat import ChatPanel
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await _open_task_screen_for_selected_detached_task(pilot)
 
@@ -369,7 +364,7 @@ async def test_inspector_scrolls_when_description_is_long() -> None:
 
 
 async def test_task_stream_uses_bounded_replay_and_merges_chunks(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from textual.containers import Vertical
@@ -391,7 +386,7 @@ async def test_task_stream_uses_bounded_replay_and_merges_chunks(
                 payload={"text": fragment, "kind": "assistant"},
             )
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     monkeypatch.setattr(app.core.tasks.events, "stream", fake_stream)
 
     async with app.run_test() as pilot:

--- a/tests/tui/test_task_screen_chat_persistence.py
+++ b/tests/tui/test_task_screen_chat_persistence.py
@@ -4,25 +4,16 @@ from tests.helpers.driver import KaganDriver
 pytestmark = [pytest.mark.tui, pytest.mark.smoke]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Task Chat Persistence Project")
-    await driver.create_task("Task chat persistence")
-    yield driver
-    await driver.teardown()
-
-
-async def test_ctrl_o_ctrl_p_toggles_keep_task_chat_session(board: KaganDriver) -> None:
+async def test_ctrl_o_ctrl_p_toggles_keep_task_chat_session(board_with_task: KaganDriver) -> None:
     from textual.widgets import Static
 
     from kagan.tui import KaganApp
     from kagan.tui.screens.task_screen import TaskScreen
     from kagan.tui.widgets.chat import ChatPanel
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -57,14 +48,16 @@ async def test_ctrl_o_ctrl_p_toggles_keep_task_chat_session(board: KaganDriver) 
         assert "session anchor" in str(panel.query_one("#chat-messages", Static).content)
 
 
-async def test_task_screen_ctrl_o_cycles_vertical_horizontal_off(board: KaganDriver) -> None:
+async def test_task_screen_ctrl_o_cycles_vertical_horizontal_off(
+    board_with_task: KaganDriver,
+) -> None:
     from kagan.tui import KaganApp
     from kagan.tui.screens.task_screen import TaskScreen
     from kagan.tui.widgets.chat import ChatPanel
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -92,14 +85,16 @@ async def test_task_screen_ctrl_o_cycles_vertical_horizontal_off(board: KaganDri
         assert not panel.has_class("visible")
 
 
-async def test_task_screen_ctrl_i_cycles_vertical_horizontal_closed(board: KaganDriver) -> None:
+async def test_task_screen_ctrl_i_cycles_vertical_horizontal_closed(
+    board_with_task: KaganDriver,
+) -> None:
     from kagan.tui import KaganApp
     from kagan.tui.screens.task_screen import TaskScreen
     from kagan.tui.widgets.chat import ChatPanel
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -124,14 +119,14 @@ async def test_task_screen_ctrl_i_cycles_vertical_horizontal_closed(board: Kagan
         assert not panel.has_class("visible")
 
 
-async def test_task_screen_ctrl_f_requires_open_overlay(board: KaganDriver) -> None:
+async def test_task_screen_ctrl_f_requires_open_overlay(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
     from kagan.tui.screens.task_screen import TaskScreen
     from kagan.tui.widgets.chat import ChatPanel
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -155,14 +150,14 @@ async def test_task_screen_ctrl_f_requires_open_overlay(board: KaganDriver) -> N
         assert panel.has_class("fullscreen")
 
 
-async def test_task_screen_ctrl_k_opens_session_picker_modal(board: KaganDriver) -> None:
+async def test_task_screen_ctrl_k_opens_session_picker_modal(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
     from kagan.tui.screens.session_picker import SessionPickerModal
     from kagan.tui.screens.task_screen import TaskScreen
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")
@@ -178,7 +173,7 @@ async def test_task_screen_ctrl_k_opens_session_picker_modal(board: KaganDriver)
 
 
 async def test_tab_in_task_chat_does_not_switch_sessions_or_layout(
-    board: KaganDriver,
+    board_with_task: KaganDriver,
 ) -> None:
     from textual.widgets import Static
 
@@ -186,9 +181,9 @@ async def test_tab_in_task_chat_does_not_switch_sessions_or_layout(
     from kagan.tui.screens.task_screen import TaskScreen
     from kagan.tui.widgets.chat import ChatPanel
 
-    task = (await board.list_tasks())[0]
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")

--- a/tests/tui/test_task_screen_resume_context.py
+++ b/tests/tui/test_task_screen_resume_context.py
@@ -10,22 +10,15 @@ from kagan.tui.screens.task_screen import TaskScreen
 pytestmark = [pytest.mark.tui]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("Resume Context Task")
-    await driver.create_task("Resume context ready")
-    yield driver
-    await driver.teardown()
+async def test_resume_context_displays_notes_for_in_progress_tasks(
+    board_with_task: KaganDriver,
+) -> None:
+    task = (await board_with_task.list_tasks())[0]
+    await board_with_task.move_task(task.id, TaskStatus.IN_PROGRESS)
+    await board_with_task.annotate(task.id, "First scratchpad note")
+    await board_with_task.annotate(task.id, "Second note with context")
 
-
-async def test_resume_context_displays_notes_for_in_progress_tasks(board: KaganDriver) -> None:
-    task = (await board.list_tasks())[0]
-    await board.move_task(task.id, TaskStatus.IN_PROGRESS)
-    await board.annotate(task.id, "First scratchpad note")
-    await board.annotate(task.id, "Second note with context")
-
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
 
@@ -42,10 +35,10 @@ async def test_resume_context_displays_notes_for_in_progress_tasks(board: KaganD
         assert "Second note with context" in content
 
 
-async def test_resume_context_hidden_for_backlog_tasks(board: KaganDriver) -> None:
-    task = (await board.list_tasks())[0]
+async def test_resume_context_hidden_for_backlog_tasks(board_with_task: KaganDriver) -> None:
+    task = (await board_with_task.list_tasks())[0]
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
 

--- a/tests/tui/test_welcome_and_onboarding.py
+++ b/tests/tui/test_welcome_and_onboarding.py
@@ -6,29 +6,20 @@ from textual.widgets import Input
 pytestmark = [pytest.mark.tui, pytest.mark.smoke]
 
 
-@pytest.fixture
-async def board(tmp_path):
-    driver = await KaganDriver.boot(tmp_path)
-    await driver.create_project("TUI Project")
-    await driver.create_task("First task")
-    yield driver
-    await driver.teardown()
-
-
-async def test_launch_shows_welcome_with_project_list(board: KaganDriver) -> None:
+async def test_launch_shows_welcome_with_project_list(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         assert app.screen.id == "welcome-screen"
         assert app.screen.query_one("#project-list") is not None
 
 
-async def test_enter_on_welcome_opens_kanban(board: KaganDriver) -> None:
+async def test_enter_on_welcome_opens_kanban(board_with_task: KaganDriver) -> None:
     from kagan.tui import KaganApp
 
-    app = KaganApp(db_path=board.tmp_path / "kagan.db")
+    app = KaganApp(db_path=board_with_task.tmp_path / "kagan.db")
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.press("enter")


### PR DESCRIPTION
## Summary

Four Zen of Python-guided refinements addressing the highest-impact code quality gaps found in a thorough codebase review:

- **Typed request models** (`server/requests.py`): Pydantic models replace manual `dict[str, Any]` extraction and `cast()` chains in all mutating API routes. Missing fields now return 422 with structured validation errors instead of opaque KeyError 400s.
- **Exception handling audit**: All `contextlib.suppress(Exception)` blocks converted to explicit `try/except` with `logger.debug`, narrowing to `KaganError | OSError` where possible. Zero silent suppressions remain.
- **Shared web utilities**: `asBool`, `normalizeLauncher`, `quoteShell` extracted from 3 components to `lib/utils.ts` with 15 unit tests. Three duplicate definitions removed.
- **Test fixture consolidation**: Shared `board_with_task` fixture replaces 7 duplicate board fixtures across TUI test files. ~90 lines of boilerplate removed.

Refinement #5 (chat SSE hook unification) is deferred to a follow-up PR due to higher complexity.

## Test plan

- [x] 745 Python tests pass (all platforms)
- [x] 149 web tests pass (including 15 new utility tests)
- [x] Ruff lint + format clean
- [x] TypeScript build passes
- [x] Server integration test updated for 422 validation responses
