### PR TITLE
refactor: apply UX refinements across TUI, web, and CLI

### DIFF
--- a/packages/web/src/components/board/create-task-dialog.test.tsx
+++ b/packages/web/src/components/board/create-task-dialog.test.tsx
@@ -8,7 +8,7 @@ vi.mock('@/lib/api/client', () => ({
   apiClient: {
     createTask: vi.fn().mockResolvedValue({}),
     getTasks: vi.fn().mockResolvedValue([]),
-    getChatAgents: vi.fn().mockResolvedValue({ backends: ['claude-code', 'codex'], default: 'claude-code' }),
+    getChatAgents: vi.fn().mockResolvedValue({ backends: [{ name: 'claude-code', available: true }, { name: 'codex', available: true }], default: 'claude-code' }),
   },
 }));
 

--- a/packages/web/src/components/board/create-task-dialog.tsx
+++ b/packages/web/src/components/board/create-task-dialog.tsx
@@ -59,7 +59,7 @@ export function CreateTaskDialog({
 
   useEffect(() => {
     if (!open) return;
-    apiClient.getChatAgents().then((data) => setBackends(data.backends)).catch(() => {});
+    apiClient.getChatAgents().then((data) => setBackends(data.backends.map((b) => b.name))).catch(() => {});
   }, [open]);
 
   useEffect(() => {

--- a/packages/web/src/components/board/edit-task-dialog.tsx
+++ b/packages/web/src/components/board/edit-task-dialog.tsx
@@ -66,7 +66,7 @@ export function EditTaskDialog({ open, onOpenChange, task, onUpdated }: EditTask
 
   useEffect(() => {
     if (!open) return;
-    apiClient.getChatAgents().then((data) => setBackends(data.backends)).catch(() => {});
+    apiClient.getChatAgents().then((data) => setBackends(data.backends.map((b) => b.name))).catch(() => {});
   }, [open]);
 
   useEffect(() => {

--- a/packages/web/src/components/board/kanban-board.tsx
+++ b/packages/web/src/components/board/kanban-board.tsx
@@ -33,7 +33,12 @@ import { BacklogListView } from '@/components/board/backlog-list-view';
 import { FirstBootTutorialDialog } from '@/components/board/first-boot-tutorial-dialog';
 import { apiClient } from '@/lib/api/client';
 import type { TaskStatus, WireTask } from '@/lib/api/types';
-import { helpOverlayOpenAtom } from '@/lib/atoms/ui';
+import {
+  createTaskDialogOpenAtom,
+  deleteTaskDialogTaskIdAtom,
+  editTaskDialogTaskIdAtom,
+  helpOverlayOpenAtom,
+} from '@/lib/atoms/ui';
 import { sseConnectedAtom } from '@/lib/atoms/connection';
 import { toast } from 'sonner';
 import { useIsMobile } from '@/lib/hooks/use-mobile';
@@ -69,7 +74,9 @@ export function KanbanBoard() {
   const [query, setQuery] = useAtom(searchQueryAtom);
   const [statusFilter, setStatusFilter] = useAtom(boardStatusFilterAtom);
   const [sort, setSort] = useAtom(boardSortAtom);
-  const [createOpen, setCreateOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useAtom(createTaskDialogOpenAtom);
+  const [editDialogTaskId, setEditDialogTaskId] = useAtom(editTaskDialogTaskIdAtom);
+  const [deleteDialogTaskId, setDeleteDialogTaskId] = useAtom(deleteTaskDialogTaskIdAtom);
   const [view, setView] = useState<'kanban' | 'backlog'>('kanban');
   const [wipLimits, setWipLimits] = useState<Record<TaskStatus, number>>(DEFAULT_WIP_LIMITS);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -101,7 +108,7 @@ export function KanbanBoard() {
     return null;
   }, [grouped, selectedTaskId]);
 
-  const { activeTask, liveTasksByStatus, sensors, collisionDetection, handleDragStart, handleDragOver, handleDragEnd } =
+  const { activeTask, liveTasksByStatus, sensors, collisionDetection, handleDragStart, handleDragOver, handleDragEnd, handleDragCancel, validDropTargets, isDragActive } =
     useBoardDnd({ tasks, grouped, fetchTasks });
 
   // Re-fetch tasks on mount and when the active project changes
@@ -193,7 +200,21 @@ export function KanbanBoard() {
 
   const openCreateDialog = useCallback(() => {
     setCreateOpen(true);
-  }, []);
+  }, [setCreateOpen]);
+
+  useEffect(() => {
+    if (!editDialogTaskId) return;
+    const task = tasks.find((t) => t.id === editDialogTaskId) ?? null;
+    if (task) setEditingTask(task);
+    setEditDialogTaskId(null);
+  }, [editDialogTaskId, tasks, setEditDialogTaskId]);
+
+  useEffect(() => {
+    if (!deleteDialogTaskId) return;
+    const task = tasks.find((t) => t.id === deleteDialogTaskId) ?? null;
+    if (task) setDeleteTask(task);
+    setDeleteDialogTaskId(null);
+  }, [deleteDialogTaskId, tasks, setDeleteDialogTaskId]);
 
   useEffect(() => {
     if (loading) return;
@@ -417,6 +438,7 @@ export function KanbanBoard() {
               onDragStart={handleDragStart}
               onDragOver={handleDragOver}
               onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
             >
               <div className="flex h-full min-h-0 min-w-0 gap-px overflow-x-auto snap-x snap-mandatory xl:grid xl:grid-cols-4 xl:overflow-x-visible xl:snap-none">
                 {COLUMN_ORDER.map((status) => (
@@ -431,6 +453,8 @@ export function KanbanBoard() {
                     onDeleteTask={setDeleteTask}
                     selectedTaskId={selectedTaskId}
                     wipLimit={wipLimits[status] ?? 0}
+                    isDragActive={isDragActive}
+                    isValidDropTarget={validDropTargets.has(status as TaskStatus)}
                     className="w-[80vw] shrink-0 snap-start sm:w-[44vw] xl:w-auto xl:shrink xl:snap-align-none"
                   />
                 ))}

--- a/packages/web/src/components/board/kanban-column.tsx
+++ b/packages/web/src/components/board/kanban-column.tsx
@@ -17,6 +17,8 @@ interface KanbanColumnProps {
   onDeleteTask?: (task: WireTask) => void;
   selectedTaskId?: string | null;
   wipLimit?: number;
+  isValidDropTarget?: boolean;
+  isDragActive?: boolean;
 }
 
 const EMPTY_COPY: Record<TaskStatus, { title: string; description: string }> = {
@@ -49,6 +51,8 @@ export function KanbanColumn({
   onDeleteTask,
   selectedTaskId,
   wipLimit = 0,
+  isValidDropTarget,
+  isDragActive,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const isOverLimit = wipLimit > 0 && tasks.length > wipLimit;
@@ -61,7 +65,9 @@ export function KanbanColumn({
       aria-label={`${STATUS_LABELS[status]}, ${tasks.length} ${tasks.length === 1 ? 'item' : 'items'}`}
       className={cn(
         'flex h-full min-h-0 min-w-0 flex-col overflow-hidden border border-border/50 bg-[color:var(--surface-1)] transition-colors duration-150',
-        isOver && 'ring-2 ring-primary/30 bg-[color:var(--surface-1)]/40',
+        isOver && isValidDropTarget && 'ring-2 ring-primary/30 bg-[color:var(--surface-1)]/40',
+        isDragActive && isValidDropTarget && !isOver && 'ring-1 ring-primary/20',
+        isDragActive && !isValidDropTarget && 'opacity-40',
         className,
       )}
     >

--- a/packages/web/src/components/board/task-card.test.tsx
+++ b/packages/web/src/components/board/task-card.test.tsx
@@ -26,7 +26,7 @@ describe('TaskCard', () => {
         })}
       />,
     );
-    expect(screen.getByText('Live')).toBeVisible();
+    expect(screen.getByTestId('live-indicator')).toBeVisible();
   });
 
   it('shows a live indicator when an interactive run is active', () => {
@@ -44,7 +44,7 @@ describe('TaskCard', () => {
         })}
       />,
     );
-    expect(screen.getByText('Live')).toBeVisible();
+    expect(screen.getByTestId('live-indicator')).toBeVisible();
   });
 
   it('calls inspector callback when provided', async () => {

--- a/packages/web/src/components/board/task-card.tsx
+++ b/packages/web/src/components/board/task-card.tsx
@@ -63,32 +63,50 @@ function formatLastActivity(value?: string | null) {
     return date.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
-function TaskCardBody({ task }: { task: WireTask }) {
+function TaskCardBody({
+    task,
+    isSelected = false,
+}: {
+    task: WireTask;
+    isSelected?: boolean;
+}) {
     const criteriaCount = task.acceptance_criteria?.length ?? 0;
 
     return (
-        <>
-            <div className="ml-2 flex h-full min-h-0 flex-col gap-0.5">
-                <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                        <p className="line-clamp-1 text-[0.84rem] font-semibold leading-4 text-[color:var(--foreground)]">
-                            {task.title}
-                        </p>
-                        <p className="font-code text-[10px] uppercase tracking-[0.16em] text-foreground/60 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
-                            {task.id}
-                        </p>
-                    </div>
-                </div>
+        <div className="ml-2 flex min-h-0 flex-col gap-0.5">
+            <div className="flex items-center justify-between gap-2">
+                <p className="line-clamp-1 text-[0.84rem] font-semibold leading-4 text-[color:var(--foreground)]">
+                    {task.title}
+                </p>
+                {task.active_session ? (
+                    <span className="inline-flex shrink-0 items-center gap-1 text-[color:var(--foreground)]" data-testid="live-indicator">
+                        <span
+                            className="size-1.5 animate-pulse rounded-full bg-[var(--primary)]"
+                            aria-hidden="true"
+                        />
+                    </span>
+                ) : null}
+            </div>
 
-                <div className="min-h-0">
-                    {task.description ? (
-                        <p className="line-clamp-1 text-[11px] leading-4 text-[var(--muted-foreground)]">
-                            {task.description}
-                        </p>
-                    ) : null}
-                </div>
+            <div
+                className={cn(
+                    "overflow-hidden transition-all duration-150",
+                    isSelected
+                        ? "max-h-20 opacity-100"
+                        : "max-h-0 opacity-0 group-hover:max-h-20 group-hover:opacity-100",
+                )}
+            >
+                <p className="font-code text-[10px] uppercase tracking-[0.16em] text-foreground/60">
+                    {task.id}
+                </p>
 
-                <div className="flex flex-wrap items-center gap-1">
+                {task.description ? (
+                    <p className="line-clamp-1 text-[11px] leading-4 text-[var(--muted-foreground)]">
+                        {task.description}
+                    </p>
+                ) : null}
+
+                <div className="mt-0.5 flex flex-wrap items-center gap-1">
                     <span className="inline-flex items-center gap-0.5 px-1 py-0 text-[9px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                         <ListChecks className="size-2.5" />
                         {criteriaCount} AC
@@ -101,24 +119,15 @@ function TaskCardBody({ task }: { task: WireTask }) {
                     ) : null}
                 </div>
 
-                <div className="mt-auto flex items-center justify-between gap-1 bg-[color:var(--surface-1)] px-2 py-0.5 text-[9px] text-muted-foreground">
+                <div className="mt-0.5 flex items-center justify-between gap-1 bg-[color:var(--surface-1)] px-2 py-0.5 text-[9px] text-muted-foreground">
                     <span className="inline-flex min-w-0 items-center truncate">
                         {formatLastActivity(
                             task.last_event_at || task.updated_at,
                         )}
                     </span>
-                    {task.active_session ? (
-                        <span className="inline-flex shrink-0 items-center gap-1 text-[color:var(--foreground)]">
-                            <span
-                                className="size-1.5 rounded-full bg-[var(--primary)]"
-                                aria-hidden="true"
-                            />
-                            Live
-                        </span>
-                    ) : null}
                 </div>
             </div>
-        </>
+        </div>
     );
 }
 
@@ -129,7 +138,7 @@ export function TaskCardOverlayPreview({
     return (
         <div
             className={cn(
-                "group relative h-[6.5rem] w-full overflow-hidden border border-border bg-card px-3 py-2 text-left shadow-lg",
+                "group relative min-h-[3.5rem] w-full overflow-hidden border border-border bg-card px-3 py-2 text-left shadow-lg",
                 className,
             )}
             role="presentation"
@@ -141,7 +150,7 @@ export function TaskCardOverlayPreview({
                     PRIORITY_RAIL[task.priority] ?? PRIORITY_RAIL.MEDIUM,
                 )}
             />
-            <TaskCardBody task={task} />
+            <TaskCardBody task={task} isSelected={true} />
         </div>
     );
 }
@@ -226,7 +235,7 @@ export function TaskCard({
                 setContextMenuOpen(true);
             }}
             className={cn(
-                "group relative h-[6.5rem] w-full cursor-grab overflow-hidden border border-border/50 bg-card px-3 py-2 text-left transition-all duration-150 hover:border-border hover:bg-[color:var(--surface-2)] active:cursor-grabbing",
+                "group relative min-h-[3.5rem] w-full cursor-grab overflow-hidden border border-border/50 bg-card px-3 py-2 text-left transition-all duration-150 hover:border-border hover:bg-[color:var(--surface-2)] active:cursor-grabbing",
                 isSelected &&
                     "ring-1 ring-[var(--primary)]/50 border-[var(--primary)]/30 bg-[color:var(--surface-2)]",
                 isDragging && "opacity-0",
@@ -252,7 +261,7 @@ export function TaskCard({
                 aria-hidden="true"
             />
 
-            <TaskCardBody task={task} />
+            <TaskCardBody task={task} isSelected={isSelected} />
         </div>
     );
 

--- a/packages/web/src/components/layout/command-palette.tsx
+++ b/packages/web/src/components/layout/command-palette.tsx
@@ -3,15 +3,22 @@ import { useLocation, useNavigate } from 'react-router';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import {
   ArrowRightLeft,
+  Check,
   Download,
   Github,
+  GitMerge,
   HelpCircle,
   LayoutDashboard,
   MessageSquare,
   PanelRight,
+  Pencil,
   Play,
+  Plus,
   Search,
   Settings,
+  Square,
+  Trash2,
+  X,
 } from 'lucide-react';
 import {
   CommandDialog,
@@ -26,10 +33,15 @@ import {
 import { tasksAtom } from '@/lib/atoms/board';
 import {
   commandPaletteOpenAtom,
+  createTaskDialogOpenAtom,
+  deleteTaskDialogTaskIdAtom,
+  editTaskDialogTaskIdAtom,
   helpOverlayOpenAtom,
   pluginImportOpenAtom,
   sessionPickerOpenAtom,
 } from '@/lib/atoms/ui';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
 
 export function CommandPalette() {
   const location = useLocation();
@@ -39,6 +51,9 @@ export function CommandPalette() {
   const setSessionPickerOpen = useSetAtom(sessionPickerOpenAtom);
   const setHelpOverlayOpen = useSetAtom(helpOverlayOpenAtom);
   const setPluginImportOpen = useSetAtom(pluginImportOpenAtom);
+  const setCreateTaskDialogOpen = useSetAtom(createTaskDialogOpenAtom);
+  const setEditTaskDialogTaskId = useSetAtom(editTaskDialogTaskIdAtom);
+  const setDeleteTaskDialogTaskId = useSetAtom(deleteTaskDialogTaskIdAtom);
 
   const currentTaskId = useMemo(() => {
     const taskMatch = /^\/task\/([^/?]+)/.exec(location.pathname);
@@ -167,6 +182,125 @@ export function CommandPalette() {
             Documentation
           </CommandItem>
         </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Task Operations">
+          <CommandItem
+            onSelect={() => {
+              onOpenChange(false);
+              setCreateTaskDialogOpen(true);
+            }}
+          >
+            <Plus className="size-4" />
+            task.new — Create task
+          </CommandItem>
+          <CommandItem
+            disabled={!currentTask}
+            onSelect={() => {
+              if (!currentTask) return;
+              onOpenChange(false);
+              setEditTaskDialogTaskId(currentTask.id);
+            }}
+          >
+            <Pencil className="size-4" />
+            task.edit — Edit selected task
+          </CommandItem>
+          <CommandItem
+            disabled={!currentTask}
+            onSelect={() => {
+              if (!currentTask) return;
+              onOpenChange(false);
+              setDeleteTaskDialogTaskId(currentTask.id);
+            }}
+          >
+            <Trash2 className="size-4" />
+            task.delete — Delete selected task
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Agent Operations">
+          <CommandItem
+            disabled={!currentTask || currentTask.status === 'DONE'}
+            onSelect={() => {
+              if (!currentTask || currentTask.status === 'DONE') return;
+              onOpenChange(false);
+              apiClient.runTask(currentTask.id).catch((err) =>
+                toast.error(err instanceof Error ? err.message : 'Failed to start task'),
+              );
+              toast.success(`Starting ${currentTask.title}`);
+            }}
+          >
+            <Play className="size-4" />
+            agent.start — Start task run
+          </CommandItem>
+          <CommandItem
+            disabled={!currentTask?.active_session}
+            onSelect={() => {
+              if (!currentTask?.active_session) return;
+              onOpenChange(false);
+              apiClient.cancelTask(currentTask.id).catch((err) =>
+                toast.error(err instanceof Error ? err.message : 'Failed to stop task'),
+              );
+              toast.success(`Stopping ${currentTask.title}`);
+            }}
+          >
+            <Square className="size-4" />
+            agent.stop — Stop task run
+          </CommandItem>
+        </CommandGroup>
+
+        {currentTask?.status === 'REVIEW' ? (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Review Operations">
+              <CommandItem
+                onSelect={() => {
+                  onOpenChange(false);
+                  apiClient
+                    .reviewDecide(currentTask.id, { action: 'approve' })
+                    .catch((err) =>
+                      toast.error(err instanceof Error ? err.message : 'Failed to approve review'),
+                    );
+                  toast.success('Review approved');
+                }}
+              >
+                <Check className="size-4" />
+                review.approve — Approve task review
+              </CommandItem>
+              <CommandItem
+                onSelect={() => {
+                  onOpenChange(false);
+                  apiClient
+                    .reviewDecide(currentTask.id, { action: 'reject' })
+                    .catch((err) =>
+                      toast.error(err instanceof Error ? err.message : 'Failed to reject review'),
+                    );
+                  toast.success('Review rejected');
+                }}
+              >
+                <X className="size-4" />
+                review.reject — Reject task review
+              </CommandItem>
+              <CommandItem
+                onSelect={() => {
+                  onOpenChange(false);
+                  apiClient
+                    .reviewDecide(currentTask.id, { action: 'merge' })
+                    .catch((err) =>
+                      toast.error(err instanceof Error ? err.message : 'Failed to merge task'),
+                    );
+                  toast.success('Merging task changes');
+                }}
+              >
+                <GitMerge className="size-4" />
+                review.merge — Merge task changes
+              </CommandItem>
+            </CommandGroup>
+          </>
+        ) : null}
 
         {sortedTasks.length > 0 ? (
           <>

--- a/packages/web/src/components/session/orchestrator-chat-panel.tsx
+++ b/packages/web/src/components/session/orchestrator-chat-panel.tsx
@@ -177,7 +177,7 @@ export function OrchestratorChatPanel({
     useEffect(() => {
         apiClient
             .getChatAgents()
-            .then((resp) => setAvailableBackends(resp.backends))
+            .then((resp) => setAvailableBackends(resp.backends.map((b) => b.name)))
             .catch(() => {});
     }, []);
 

--- a/packages/web/src/components/settings/agent-picker.tsx
+++ b/packages/web/src/components/settings/agent-picker.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Bot, Check } from 'lucide-react';
 import { apiClient } from '@/lib/api/client';
+import type { AgentBackend } from '@/lib/api/types';
 import { Card } from '@/components/ui/card';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function AgentPicker() {
-  const [backends, setBackends] = useState<string[]>([]);
+  const [backends, setBackends] = useState<AgentBackend[]>([]);
   const [defaultBackend, setDefaultBackend] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -15,7 +17,11 @@ export function AgentPicker() {
     (async () => {
       try {
         const data = await apiClient.getChatAgents();
-        setBackends(data.backends);
+        const sorted = [...data.backends].sort((a, b) => {
+          if (a.available === b.available) return 0;
+          return a.available ? -1 : 1;
+        });
+        setBackends(sorted);
         setDefaultBackend(data.default);
       } catch {
         toast.error('Failed to load agent backends');
@@ -56,23 +62,26 @@ export function AgentPicker() {
         <div className="flex flex-wrap gap-2">
           {backends.map((backend) => (
             <Button
-              key={backend}
+              key={backend.name}
               variant="outline"
               size="xs"
-              onClick={() => selectBackend(backend)}
+              onClick={() => selectBackend(backend.name)}
               disabled={saving}
-              className={`transition-colors ${
-                backend === defaultBackend
+              title={!backend.available ? 'Not installed' : undefined}
+              className={cn(
+                'transition-colors',
+                backend.name === defaultBackend
                   ? 'border-[var(--primary)] bg-[var(--primary)]/10 text-[var(--primary)]'
-                  : 'border-[color:var(--border-subtle)] text-[var(--muted-foreground)] hover:bg-[color:var(--surface-2)]'
-              }`}
+                  : 'border-[color:var(--border-subtle)] text-[var(--muted-foreground)] hover:bg-[color:var(--surface-2)]',
+                !backend.available && 'opacity-40',
+              )}
             >
-              {backend === defaultBackend ? (
+              {backend.name === defaultBackend ? (
                 <Check className="size-3" />
               ) : (
                 <Bot className="size-3" />
               )}
-              {backend}
+              {backend.name}
             </Button>
           ))}
         </div>

--- a/packages/web/src/components/settings/settings-panel.tsx
+++ b/packages/web/src/components/settings/settings-panel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAtom, useSetAtom } from 'jotai';
+import { Check, Undo2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiClient } from '@/lib/api/client';
 import { themeModeAtom, setThemeModeAtom } from '@/lib/atoms/theme';
@@ -7,6 +8,8 @@ import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
 import {
   Field,
   FieldContent,
@@ -18,11 +21,6 @@ import {
   FieldSet,
 } from '@/components/ui/field';
 import { asBool } from '@/lib/utils';
-import { AppearanceSettings } from './sections/appearance-settings';
-import { WorkflowSettings } from './sections/workflow-settings';
-import { WorkspaceSettings } from './sections/workspace-settings';
-import { OrchestrationSettings } from './sections/orchestration-settings';
-import { AdditionalInstructionsSettings } from './sections/additional-instructions';
 
 type ThemeMode = 'system' | 'dark' | 'light';
 
@@ -113,7 +111,6 @@ export function SettingsPanel() {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
 
-  /** Save a single field atomically to the API. */
   const saveField = async <K extends keyof SettingsFormState>(
     key: K,
     value: SettingsFormState[K],
@@ -140,7 +137,7 @@ export function SettingsPanel() {
           apiClient.getChatAgents(),
         ]);
 
-        setAvailableBackends(agents.backends);
+        setAvailableBackends(agents.backends.map((b) => b.name));
 
         setResolvedGit({
           name: resolved.git_user_name || '',
@@ -212,6 +209,10 @@ export function SettingsPanel() {
     }
   };
 
+  const detectedDotfileOverrides = Object.entries(dotfileOverrides)
+    .filter(([, v]) => v != null)
+    .map(([k]) => k);
+
   return (
     <Card className="overflow-hidden p-0">
 
@@ -223,30 +224,9 @@ export function SettingsPanel() {
         </div>
       ) : (
         <FieldGroup className="space-y-0 px-5 py-5">
-          <OrchestrationSettings form={form} saveField={saveField} />
-
-          <FieldSeparator />
-
-          <AppearanceSettings
-            form={form}
-            setField={setField}
-            saveField={saveField}
-            themeMode={themeMode as ThemeMode}
-            setThemeMode={(mode) => setThemeMode(mode)}
-          />
-
-          <FieldSeparator />
-
-          <WorkflowSettings form={form} saveField={saveField} />
-
-          <FieldSeparator />
-
-          <WorkspaceSettings form={form} setField={setField} saveField={saveField} />
-
-          <FieldSeparator />
 
           <FieldSet>
-            <FieldLegend variant="label">Identity and Models</FieldLegend>
+            <FieldLegend variant="label">Essentials</FieldLegend>
             <Field>
               <FieldLabel>Default agent backend</FieldLabel>
               <FieldDescription>Agent used for new tasks when none is specified.</FieldDescription>
@@ -263,6 +243,88 @@ export function SettingsPanel() {
                 )}
               </NativeSelect>
             </Field>
+            <Field>
+              <FieldLabel>Theme</FieldLabel>
+              <FieldDescription>Choose how Kagan renders across desktop and mobile surfaces.</FieldDescription>
+              <NativeSelect
+                value={themeMode}
+                onChange={(event) => setThemeMode(event.target.value as ThemeMode)}
+              >
+                <NativeSelectOption value="system">Follow system</NativeSelectOption>
+                <NativeSelectOption value="dark">Dark</NativeSelectOption>
+                <NativeSelectOption value="light">Light</NativeSelectOption>
+              </NativeSelect>
+            </Field>
+            <Field>
+              <FieldLabel>Instructions</FieldLabel>
+              <FieldDescription>Appended to every agent prompt — your preferences, conventions, and workflow rules.</FieldDescription>
+              <Textarea
+                rows={4}
+                value={form.additional_instructions}
+                onChange={(event) => setField('additional_instructions', event.target.value)}
+                placeholder="Use conventional commits · Explain tradeoffs first · Commit messages in Portuguese"
+              />
+              {form.additional_instructions !== savedRef.current.additional_instructions && (
+                <div className="flex items-center justify-end gap-2 pt-1.5">
+                  <span className="text-[11px] text-[var(--muted-foreground)]">Unsaved changes</span>
+                  <Button variant="ghost" size="xs" onClick={() => setField('additional_instructions', savedRef.current.additional_instructions)}>
+                    <Undo2 className="size-3" /> Discard
+                  </Button>
+                  <Button size="xs" onClick={() => saveField('additional_instructions', form.additional_instructions)}>
+                    <Check className="size-3" /> Apply
+                  </Button>
+                </div>
+              )}
+              <div className="pt-2 text-[11px] text-[var(--muted-foreground)]">
+                {detectedDotfileOverrides.length > 0 ? (
+                  <span>Prompt overrides active: <strong>{detectedDotfileOverrides.join(', ')}</strong></span>
+                ) : (
+                  <span>Full prompt overrides → <code className="text-[10px]">.kagan/prompts/</code></span>
+                )}
+              </div>
+            </Field>
+          </FieldSet>
+
+          <FieldSeparator />
+
+          <FieldSet>
+            <FieldLegend variant="label">Workflow</FieldLegend>
+            <ToggleRow
+              title="Auto review"
+              description="Run review checks automatically when task execution completes."
+              checked={form.auto_review}
+              onCheckedChange={(value) => saveField('auto_review', value)}
+            />
+            <ToggleRow
+              title="Require review approval"
+              description="Block merge transitions unless reviewer approval is present."
+              checked={form.require_review_approval}
+              onCheckedChange={(value) => saveField('require_review_approval', value)}
+            />
+            <ToggleRow
+              title="Auto-confirm single tasks"
+              description="Skip the confirmation step for single-task plans and proceed directly to execution."
+              checked={form.auto_confirm_single_tasks}
+              onCheckedChange={(value) => saveField('auto_confirm_single_tasks', value)}
+            />
+            <Field>
+              <FieldLabel>Review strictness</FieldLabel>
+              <FieldDescription>Controls how thoroughly task outputs are reviewed before approval.</FieldDescription>
+              <NativeSelect
+                value={form.review_strictness}
+                onChange={(event) => saveField('review_strictness', event.target.value)}
+              >
+                <NativeSelectOption value="strict">Strict</NativeSelectOption>
+                <NativeSelectOption value="balanced">Balanced</NativeSelectOption>
+                <NativeSelectOption value="relaxed">Relaxed</NativeSelectOption>
+              </NativeSelect>
+            </Field>
+          </FieldSet>
+
+          <FieldSeparator />
+
+          <FieldSet>
+            <FieldLegend variant="label">Git</FieldLegend>
             <Field>
               <FieldLabel>Git identity mode</FieldLabel>
               <FieldDescription>Choose between managed, system, or custom commit identity.</FieldDescription>
@@ -295,36 +357,116 @@ export function SettingsPanel() {
               />
             </Field>
             <Field>
-              <FieldLabel>Default Claude model</FieldLabel>
-              <FieldDescription>Default model hint when using Claude-family agents.</FieldDescription>
+              <FieldLabel>Default base branch</FieldLabel>
+              <FieldDescription>Base branch used for task worktrees when none is specified.</FieldDescription>
               <Input
-                value={form.default_model_claude}
-                onChange={(event) => setField('default_model_claude', event.target.value)}
-                onBlur={() => saveField('default_model_claude', form.default_model_claude)}
-                placeholder="Uses agent default"
-              />
-            </Field>
-            <Field>
-              <FieldLabel>Default OpenAI model</FieldLabel>
-              <FieldDescription>Default model hint when using OpenAI-family agents.</FieldDescription>
-              <Input
-                value={form.default_model_openai}
-                onChange={(event) => setField('default_model_openai', event.target.value)}
-                onBlur={() => saveField('default_model_openai', form.default_model_openai)}
-                placeholder="Uses agent default"
+                value={form.default_base_branch}
+                onChange={(event) => setField('default_base_branch', event.target.value)}
+                onBlur={() => saveField('default_base_branch', form.default_base_branch)}
               />
             </Field>
           </FieldSet>
 
           <FieldSeparator />
 
-          <AdditionalInstructionsSettings
-            form={form}
-            savedValue={savedRef.current.additional_instructions}
-            setField={setField}
-            saveField={saveField}
-            dotfileOverrides={dotfileOverrides}
-          />
+          <FieldSet>
+            <details className="space-y-6">
+              <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
+                Advanced settings
+              </summary>
+              <Field>
+                <FieldLabel>Worktree base strategy</FieldLabel>
+                <FieldDescription>Controls whether worktrees anchor to local or remote references.</FieldDescription>
+                <NativeSelect
+                  value={form.worktree_base_ref_strategy}
+                  onChange={(event) => saveField('worktree_base_ref_strategy', event.target.value)}
+                >
+                  <NativeSelectOption value="local_if_ahead">local_if_ahead</NativeSelectOption>
+                  <NativeSelectOption value="remote">remote</NativeSelectOption>
+                  <NativeSelectOption value="local">local</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field>
+                <FieldLabel>Planning depth</FieldLabel>
+                <FieldDescription>When the orchestrator creates detailed task plans before execution.</FieldDescription>
+                <NativeSelect
+                  value={form.planning_depth}
+                  onChange={(event) => saveField('planning_depth', event.target.value)}
+                >
+                  <NativeSelectOption value="always">Always plan</NativeSelectOption>
+                  <NativeSelectOption value="multi_task">Multi-task only</NativeSelectOption>
+                  <NativeSelectOption value="never">Never plan</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <ToggleRow
+                title="Serialize merges"
+                description="Queue manual merges to avoid branch collision under high throughput."
+                checked={form.serialize_merges}
+                onCheckedChange={(value) => saveField('serialize_merges', value)}
+              />
+              <ToggleRow
+                title="Auto-initialize git repository"
+                description="Initialize git automatically when creating a fresh workspace."
+                checked={form.auto_init_git_repo}
+                onCheckedChange={(value) => saveField('auto_init_git_repo', value)}
+              />
+              <ToggleRow
+                title="Create initial commit automatically"
+                description="Create a bootstrap commit after automatic repository initialization."
+                checked={form.auto_init_git_initial_commit}
+                onCheckedChange={(value) => saveField('auto_init_git_initial_commit', value)}
+              />
+              <Field>
+                <FieldLabel>Interactive launcher</FieldLabel>
+                <FieldDescription>Primary tool used when you attach an interactive run.</FieldDescription>
+                <NativeSelect
+                  value={form.attached_launcher}
+                  onChange={(event) => saveField('attached_launcher', event.target.value)}
+                >
+                  <NativeSelectOption value="tmux">tmux</NativeSelectOption>
+                  <NativeSelectOption value="nvim">nvim</NativeSelectOption>
+                  <NativeSelectOption value="vscode">vscode</NativeSelectOption>
+                  <NativeSelectOption value="cursor">cursor</NativeSelectOption>
+                  <NativeSelectOption value="windsurf">windsurf</NativeSelectOption>
+                  <NativeSelectOption value="kiro">kiro</NativeSelectOption>
+                  <NativeSelectOption value="antigravity">antigravity</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <ToggleRow
+                title="Restore last workspace on startup"
+                description="Resume directly in your recent project context after app launch."
+                checked={form.open_last_project_on_startup}
+                onCheckedChange={(value) => saveField('open_last_project_on_startup', value)}
+              />
+              <ToggleRow
+                title="Show attach guidance"
+                description="Keep onboarding instructions visible when attaching an interactive run."
+                checked={!form.skip_attached_instructions_popup}
+                onCheckedChange={(value) => saveField('skip_attached_instructions_popup', !value)}
+              />
+              <Field>
+                <FieldLabel>Default Claude model</FieldLabel>
+                <FieldDescription>Default model hint when using Claude-family agents.</FieldDescription>
+                <Input
+                  value={form.default_model_claude}
+                  onChange={(event) => setField('default_model_claude', event.target.value)}
+                  onBlur={() => saveField('default_model_claude', form.default_model_claude)}
+                  placeholder="Uses agent default"
+                />
+              </Field>
+              <Field>
+                <FieldLabel>Default OpenAI model</FieldLabel>
+                <FieldDescription>Default model hint when using OpenAI-family agents.</FieldDescription>
+                <Input
+                  value={form.default_model_openai}
+                  onChange={(event) => setField('default_model_openai', event.target.value)}
+                  onBlur={() => saveField('default_model_openai', form.default_model_openai)}
+                  placeholder="Uses agent default"
+                />
+              </Field>
+            </details>
+          </FieldSet>
+
         </FieldGroup>
       )}
     </Card>

--- a/packages/web/src/lib/api/types.ts
+++ b/packages/web/src/lib/api/types.ts
@@ -85,8 +85,13 @@ export interface CreateChatSessionInput {
     label?: string;
 }
 
+export interface AgentBackend {
+    name: string;
+    available: boolean;
+}
+
 export interface ChatAgentsResponse {
-    backends: string[];
+    backends: AgentBackend[];
     default: string;
 }
 

--- a/packages/web/src/lib/atoms/ui.ts
+++ b/packages/web/src/lib/atoms/ui.ts
@@ -26,6 +26,16 @@ export const helpOverlayOpenAtom = atom(false);
 
 /** Plugin import dialog open state. */
 export const pluginImportOpenAtom = atom(false);
+
+/** Create task dialog open state (used by command palette). */
+export const createTaskDialogOpenAtom = atom(false);
+
+/** Edit task dialog task ID (used by command palette; null = closed). */
+export const editTaskDialogTaskIdAtom = atom<string | null>(null);
+
+/** Delete task dialog task ID (used by command palette; null = closed). */
+export const deleteTaskDialogTaskIdAtom = atom<string | null>(null);
+
 /** Track whether any dialog/modal is open to pause background refetches. */
 export const dialogOpenCountAtom = atom(0);
 

--- a/packages/web/src/lib/hooks/use-board-dnd.ts
+++ b/packages/web/src/lib/hooks/use-board-dnd.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import {
     PointerSensor,
     pointerWithin,
+    type DragCancelEvent,
     type DragEndEvent,
     type DragOverEvent,
     type DragStartEvent,
@@ -12,6 +13,7 @@ import type { TaskStatus, WireTask } from "@/lib/api/types";
 import {
     COLUMN_ORDER,
     STATUS_LABELS,
+    ALLOWED_TASK_TRANSITIONS,
     isAllowedTaskTransition,
 } from "@/lib/utils/constants";
 import { apiClient } from "@/lib/api/client";
@@ -31,6 +33,9 @@ interface UseBoardDndReturn {
     handleDragStart: (e: DragStartEvent) => void;
     handleDragOver: (e: DragOverEvent) => void;
     handleDragEnd: (e: DragEndEvent) => void;
+    handleDragCancel: (e: DragCancelEvent) => void;
+    validDropTargets: Set<TaskStatus>;
+    isDragActive: boolean;
 }
 
 export function useBoardDnd({
@@ -43,6 +48,7 @@ export function useBoardDnd({
         TaskStatus,
         WireTask[]
     > | null>(null);
+    const [validDropTargets, setValidDropTargets] = useState<Set<TaskStatus>>(new Set());
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -52,6 +58,9 @@ export function useBoardDnd({
         (e: DragStartEvent) => {
             const task = tasks.find((item) => item.id === e.active.id);
             setActiveTask(task ?? null);
+            if (task) {
+                setValidDropTargets(new Set(ALLOWED_TASK_TRANSITIONS[task.status as TaskStatus]));
+            }
         },
         [tasks],
     );
@@ -102,6 +111,7 @@ export function useBoardDnd({
         async (e: DragEndEvent) => {
             setActiveTask(null);
             setDragState(null);
+            setValidDropTargets(new Set());
 
             const { active, over } = e;
             if (!over) return;
@@ -145,6 +155,12 @@ export function useBoardDnd({
         [fetchTasks, tasks],
     );
 
+    const handleDragCancel = useCallback((_e: DragCancelEvent) => {
+        setActiveTask(null);
+        setDragState(null);
+        setValidDropTargets(new Set());
+    }, []);
+
     return {
         activeTask,
         liveTasksByStatus: dragState ?? grouped,
@@ -153,5 +169,8 @@ export function useBoardDnd({
         handleDragStart,
         handleDragOver,
         handleDragEnd,
+        handleDragCancel,
+        validDropTargets,
+        isDragActive: activeTask !== null,
     };
 }

--- a/packages/web/src/lib/utils/constants.ts
+++ b/packages/web/src/lib/utils/constants.ts
@@ -2,7 +2,7 @@ import type { TaskStatus, Priority } from '@/lib/api/types';
 
 export const COLUMN_ORDER: TaskStatus[] = ['BACKLOG', 'IN_PROGRESS', 'REVIEW', 'DONE'];
 
-const ALLOWED_TASK_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+export const ALLOWED_TASK_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
   BACKLOG: ['IN_PROGRESS'],
   IN_PROGRESS: ['BACKLOG', 'REVIEW'],
   REVIEW: ['BACKLOG', 'IN_PROGRESS'],

--- a/packages/web/src/pages/chat-page.tsx
+++ b/packages/web/src/pages/chat-page.tsx
@@ -115,7 +115,7 @@ export function Component() {
 
   // ── Fetch available backends ────────────────────────────────────────────────
   useEffect(() => {
-    apiClient.getChatAgents().then((resp) => setAvailableBackends(resp.backends)).catch(() => {});
+    apiClient.getChatAgents().then((resp) => setAvailableBackends(resp.backends.map((b) => b.name))).catch(() => {});
   }, []);
 
   const switchBackend = useCallback(

--- a/packages/web/src/pages/task-detail-page.tsx
+++ b/packages/web/src/pages/task-detail-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router";
 import {
     ArrowLeft,
@@ -99,7 +99,8 @@ export function Component() {
         initialLimit: 80,
     });
 
-    // 2.4: Always read tab from URL params — URL is the source of truth
+    // 2.4: Set initial tab from URL or task status — only on first load / task change
+    const prevTaskIdRef = useRef<string | null>(null);
     useEffect(() => {
         if (!task) return;
         const urlTab = searchParams.get("tab");
@@ -109,9 +110,10 @@ export function Component() {
             urlTab === "review"
         ) {
             setActiveTab(urlTab);
-        } else {
+        } else if (prevTaskIdRef.current !== task.id) {
             setActiveTab(defaultTabForTask(task));
         }
+        prevTaskIdRef.current = task.id;
     }, [task, searchParams]);
 
     useEffect(() => {

--- a/src/kagan/chat/agents.py
+++ b/src/kagan/chat/agents.py
@@ -1,6 +1,7 @@
 """Agent backend listing, selection, and formatting."""
 
 from kagan.core import list_backends
+from kagan.core._agent import list_available_backends
 
 
 def list_registered_agent_backends() -> list[str]:
@@ -59,6 +60,11 @@ def format_agent_usage() -> str:
 
 def format_agent_switching(backend: str) -> str:
     return f"Switching to {backend}..."
+
+
+def list_backends_with_availability() -> list[dict[str, str | bool]]:
+    availability = list_available_backends()
+    return [{"name": name, "available": avail} for name, avail in availability.items()]
 
 
 def resolve_default_agent_backend(settings: dict[str, str]) -> str:

--- a/src/kagan/cli/main.py
+++ b/src/kagan/cli/main.py
@@ -148,12 +148,12 @@ def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> 
     invoke_without_command=True,
     help="ᘚᘛ Kagan — one orchestration layer to rule them all.",
     epilog=(
-        "Examples:\n"
-        "  kagan                     Launch the TUI\n"
-        "  kagan chat --prompt '...' Single-shot agent prompt\n"
+        "Common workflows:\n"
+        "  kagan                     Launch the Kanban TUI\n"
+        "  kagan chat 'fix the bug'  Single-shot agent prompt\n"
         "  kagan web                 Open the web dashboard\n"
-        "  kagan doctor              Check system health\n"
-        "  kagan import github       Import GitHub issues"
+        "  kagan doctor              Check system health\n\n"
+        "Full reference: https://docs.kagan.sh/reference/cli/"
     ),
 )
 @click.option(
@@ -186,6 +186,10 @@ def cli(ctx: click.Context, skip_update_check: bool, verbose: bool) -> None:
         click.echo(f"hint: kagan {latest} available. Run `kagan update`.")
 
     if ctx.invoked_subcommand is None:
+        import sys
+
+        if sys.stdout.isatty():
+            click.echo("ᘚᘛ Kagan — launching TUI. Run 'kagan --help' for all commands.")
         tui_cmd = cli.commands.get("tui")
         if tui_cmd is None:
             raise click.ClickException("TUI command not available")

--- a/src/kagan/core/_agent.py
+++ b/src/kagan/core/_agent.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Final, TypedDict, cast
 
@@ -234,7 +233,6 @@ def list_backends() -> list[str]:
     return list(AGENT_BACKENDS)
 
 
-@lru_cache(maxsize=1)
 def list_available_backends() -> dict[str, bool]:
     """Return {backend_name: is_installed} for all registered backends."""
     return {

--- a/src/kagan/core/_agent.py
+++ b/src/kagan/core/_agent.py
@@ -8,9 +8,11 @@ spawn_agent() writes .mcp.json to the worktree and spawns a detached OS process.
 import asyncio
 import errno
 import json
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Final, TypedDict, cast
 
@@ -230,6 +232,15 @@ def get_backend(name: str) -> AgentBackendConfig:
 def list_backends() -> list[str]:
     """Return all registered backend names."""
     return list(AGENT_BACKENDS)
+
+
+@lru_cache(maxsize=1)
+def list_available_backends() -> dict[str, bool]:
+    """Return {backend_name: is_installed} for all registered backends."""
+    return {
+        name: shutil.which(cfg["executable"]) is not None
+        for name, cfg in AGENT_BACKENDS.items()
+    }
 
 
 def build_agent_environment(

--- a/src/kagan/core/_transitions.py
+++ b/src/kagan/core/_transitions.py
@@ -41,3 +41,14 @@ def can_merge_move(from_status: TaskStatus, to_status: TaskStatus) -> bool:
 def validate_merge_move(from_status: TaskStatus, to_status: TaskStatus) -> None:
     if not can_merge_move(from_status, to_status):
         raise InvalidTransitionError(from_status, to_status)
+
+
+def allowed_targets(status: TaskStatus) -> list[TaskStatus]:
+    """Return valid transition targets for a given status (excluding merge-only)."""
+    return [to for (frm, to) in _ALLOWED if frm == status]
+
+
+def all_allowed_targets(status: TaskStatus) -> list[TaskStatus]:
+    """Return all valid targets including merge transitions."""
+    merge = [to for (frm, to) in _MERGE_ALLOWED if frm == status]
+    return allowed_targets(status) + merge

--- a/src/kagan/server/_chat_routes.py
+++ b/src/kagan/server/_chat_routes.py
@@ -339,9 +339,9 @@ def _register_crud_routes(mcp: FastMCP) -> None:
     @handle_errors
     async def list_agents(_request: Request, *, ctx: Any) -> JSONResponse:
         """List available agent backends."""
-        from kagan.chat.agents import list_registered_agent_backends
+        from kagan.chat.agents import list_backends_with_availability
 
-        backends = list_registered_agent_backends()
+        backends = list_backends_with_availability()
         settings = await ctx.client.settings.get()
         default = settings.get("default_agent_backend") or "claude-code"
         return _ok({"backends": backends, "default": default})

--- a/src/kagan/tui/keybindings.py
+++ b/src/kagan/tui/keybindings.py
@@ -84,8 +84,9 @@ KANBAN_BINDINGS: list[BindingType] = [
 ]
 
 TASK_SCREEN_BINDINGS: list[BindingType] = [
-    Binding("1", "tab_detail", "Detail"),
-    Binding("2", "tab_diff", "Diff"),
+    Binding("1", "tab_overview", "Overview"),
+    Binding("2", "tab_changes", "Changes"),
+    Binding("3", "tab_review", "Review"),
     Binding("enter", "primary_action", "Primary Action"),
     Binding("e", "edit_task", "Edit"),
     Binding("d", "delete_task", "Delete"),

--- a/src/kagan/tui/screens/agent_picker.py
+++ b/src/kagan/tui/screens/agent_picker.py
@@ -8,6 +8,7 @@ from textual.widgets import Footer, OptionList, Static
 from textual.widgets.option_list import Option
 
 from kagan.chat import list_registered_agent_backends
+from kagan.core._agent import list_available_backends
 from kagan.tui.keybindings import AGENT_PICKER_BINDINGS
 
 if TYPE_CHECKING:
@@ -26,6 +27,7 @@ class AgentPickerModal(ModalScreen[str | None]):
         super().__init__(id="agent-picker-modal")
         self._agents: list[str] = []
         self._current_agent = "claude-code"
+        self._separator_index: int | None = None
 
     @property
     def kagan_app(self) -> "KaganApp":
@@ -48,37 +50,54 @@ class AgentPickerModal(ModalScreen[str | None]):
         normalized_configured = self._BACKEND_ALIASES.get(configured or "", configured)
         self._current_agent = normalized_configured or "claude-code"
 
-        options = {self._current_agent, *list_registered_agent_backends()}
-        self._agents = sorted(options)
+        all_agents = sorted({self._current_agent, *list_registered_agent_backends()})
+        availability = list_available_backends()
+
+        available = [a for a in all_agents if availability.get(a, True)]
+        unavailable = [a for a in all_agents if not availability.get(a, True)]
+        self._agents = available + unavailable
 
         option_list = self.query_one("#agent-picker-options", OptionList)
         option_list.clear_options()
-        option_list.add_options(
-            [
-                Option(
-                    f"{agent}{' (current)' if agent == self._current_agent else ''}",
-                    id=agent,
-                )
-                for agent in self._agents
-            ]
-        )
+
+        for agent in available:
+            label = f"{agent}{' (current)' if agent == self._current_agent else ''}"
+            option_list.add_option(Option(label, id=agent))
+
+        if unavailable:
+            self._separator_index = len(available)
+            option_list.add_option(Option("[dim]── Not installed ──[/dim]", disabled=True))
+            for agent in unavailable:
+                label = f"[dim]{agent}{' (current)' if agent == self._current_agent else ''}[/dim]"
+                option_list.add_option(Option(label, id=agent))
+
         option_list.focus()
 
         selected_index = 0
         for index, agent in enumerate(self._agents):
             if agent == self._current_agent:
-                selected_index = index
+                after_sep = self._separator_index is not None and index >= self._separator_index
+                selected_index = index + 1 if after_sep else index
                 break
         option_list.highlighted = selected_index
 
     async def action_select_agent(self) -> None:
         option_list = self.query_one("#agent-picker-options", OptionList)
         index = option_list.highlighted
-        if index is None or index < 0 or index >= len(self._agents):
+        if index is None or index < 0:
             self.dismiss(None)
             return
 
-        selected = self._agents[index]
+        if self._separator_index is not None and index == self._separator_index:
+            return
+
+        after_sep = self._separator_index is not None and index > self._separator_index
+        agent_index = index - 1 if after_sep else index
+        if agent_index >= len(self._agents):
+            self.dismiss(None)
+            return
+
+        selected = self._agents[agent_index]
         await self.kagan_app.core.settings.set(
             {
                 "default_agent_backend": selected,

--- a/src/kagan/tui/screens/settings.py
+++ b/src/kagan/tui/screens/settings.py
@@ -148,81 +148,41 @@ class SettingsModal(ModalScreen[None]):
         self._auto_save_timer: Timer | None = None
         self._categories = [
             SettingCategory(
-                id="orchestration",
-                name="Orchestration",
-                search_terms=("review", "strict", "planning", "confirm"),
+                id="essentials",
+                name="Essentials",
+                search_terms=(
+                    "agent", "backend", "theme", "appearance", "color",
+                    "instructions", "custom", "prompt", "additional", "dotfile",
+                ),
             ),
             SettingCategory(
-                id="general",
-                name="General",
-                search_terms=("agent", "launcher", "base", "branch", "startup", "recent"),
+                id="workflow",
+                name="Workflow",
+                search_terms=(
+                    "review", "strict", "planning", "confirm", "auto", "approval", "merge",
+                ),
             ),
             SettingCategory(
-                id="automation",
-                name="Automation",
-                search_terms=("auto", "review", "init", "commit"),
+                id="git",
+                name="Git",
+                search_terms=(
+                    "git", "user", "name", "email", "identity", "agent", "kagan",
+                    "base", "branch",
+                ),
             ),
             SettingCategory(
-                id="merge",
-                name="Merge Policy",
-                search_terms=("merge", "approval", "review", "serialize"),
-            ),
-            SettingCategory(
-                id="appearance",
-                name="Appearance",
-                search_terms=("theme", "appearance", "color", "attached", "instructions"),
-            ),
-            SettingCategory(
-                id="worktree",
-                name="Worktree",
-                search_terms=("strategy", "ref", "remote", "local"),
-            ),
-            SettingCategory(
-                id="instructions",
-                name="Additional Instructions",
-                search_terms=("instructions", "custom", "prompt", "additional", "dotfile"),
-                is_advanced=True,
-            ),
-            SettingCategory(
-                id="git_identity",
-                name="Git Identity",
-                search_terms=("git", "user", "name", "email", "identity", "agent", "kagan"),
-                is_advanced=True,
-            ),
-            SettingCategory(
-                id="models",
-                name="Models",
-                search_terms=("model", "claude", "openai", "default", "backend"),
+                id="advanced",
+                name="Advanced",
+                search_terms=(
+                    "worktree", "strategy", "ref", "remote", "local", "serialize",
+                    "init", "commit", "launcher", "startup", "recent", "model",
+                    "claude", "openai", "attached", "instructions", "popup",
+                ),
                 is_advanced=True,
             ),
         ]
         self._category_fields: dict[str, tuple[SettingFieldSpec, ...]] = {
-            "orchestration": (
-                SettingFieldSpec(
-                    "switch", "Auto-confirm plans for single tasks", "settings-auto-confirm-single"
-                ),
-                SettingFieldSpec(
-                    "select",
-                    "Review strictness",
-                    "settings-review-strictness",
-                    options=(
-                        ("Strict", "strict"),
-                        ("Balanced", "balanced"),
-                        ("Relaxed", "relaxed"),
-                    ),
-                ),
-                SettingFieldSpec(
-                    "select",
-                    "Planning depth",
-                    "settings-planning-depth",
-                    options=(
-                        ("Always plan", "always"),
-                        ("Multi-task only", "multi_task"),
-                        ("Never plan", "never"),
-                    ),
-                ),
-            ),
-            "general": (
+            "essentials": (
                 SettingFieldSpec(
                     "select",
                     "Default agent backend",
@@ -231,62 +191,10 @@ class SettingsModal(ModalScreen[None]):
                 ),
                 SettingFieldSpec(
                     "select",
-                    "Interactive launcher",
-                    "settings-attached-launcher",
-                    options=(
-                        ("tmux", "tmux"),
-                        ("nvim", "nvim"),
-                        ("vscode", "vscode"),
-                        ("cursor", "cursor"),
-                        ("windsurf", "windsurf"),
-                        ("kiro", "kiro"),
-                        ("antigravity", "antigravity"),
-                    ),
-                ),
-                SettingFieldSpec("text", "Default base branch", "settings-default-base-branch"),
-                SettingFieldSpec(
-                    "switch", "Open last project on launch", "settings-open-last-project"
-                ),
-            ),
-            "worktree": (
-                SettingFieldSpec(
-                    "select",
-                    "Worktree base ref strategy",
-                    "settings-base-ref-strategy",
-                    options=(
-                        ("Local if ahead", "local_if_ahead"),
-                        ("Remote", "remote"),
-                        ("Local", "local"),
-                    ),
-                ),
-            ),
-            "automation": (
-                SettingFieldSpec("switch", "Enable auto review", "settings-auto-review"),
-                SettingFieldSpec("switch", "Auto init git repo", "settings-auto-init-repo"),
-                SettingFieldSpec(
-                    "switch", "Auto create initial commit", "settings-auto-init-commit"
-                ),
-            ),
-            "merge": (
-                SettingFieldSpec(
-                    "switch", "Require approval before merge", "settings-require-review-approval"
-                ),
-                SettingFieldSpec("switch", "Serialize manual merges", "settings-serialize-merges"),
-            ),
-            "appearance": (
-                SettingFieldSpec(
-                    "select",
                     "Theme",
                     "settings-theme",
                     options_factory=_build_theme_options,
                 ),
-                SettingFieldSpec(
-                    "switch",
-                    "Skip attach instructions popup",
-                    "settings-skip-attached-instructions",
-                ),
-            ),
-            "instructions": (
                 SettingFieldSpec(
                     "textarea", "Additional instructions", "settings-additional-instructions"
                 ),
@@ -306,7 +214,26 @@ class SettingsModal(ModalScreen[None]):
                     text="[dim]Full prompt overrides -> .kagan/prompts/[/dim]",
                 ),
             ),
-            "git_identity": (
+            "workflow": (
+                SettingFieldSpec("switch", "Enable auto review", "settings-auto-review"),
+                SettingFieldSpec(
+                    "switch", "Require approval before merge", "settings-require-review-approval"
+                ),
+                SettingFieldSpec(
+                    "switch", "Auto-confirm plans for single tasks", "settings-auto-confirm-single"
+                ),
+                SettingFieldSpec(
+                    "select",
+                    "Review strictness",
+                    "settings-review-strictness",
+                    options=(
+                        ("Strict", "strict"),
+                        ("Balanced", "balanced"),
+                        ("Relaxed", "relaxed"),
+                    ),
+                ),
+            ),
+            "git": (
                 SettingFieldSpec(
                     "select",
                     "Git user mode",
@@ -319,8 +246,56 @@ class SettingsModal(ModalScreen[None]):
                 ),
                 SettingFieldSpec("text", "Git user name (custom mode)", "settings-git-user-name"),
                 SettingFieldSpec("text", "Git email (custom mode)", "settings-git-user-email"),
+                SettingFieldSpec("text", "Default base branch", "settings-default-base-branch"),
             ),
-            "models": (
+            "advanced": (
+                SettingFieldSpec(
+                    "select",
+                    "Worktree base ref strategy",
+                    "settings-base-ref-strategy",
+                    options=(
+                        ("Local if ahead", "local_if_ahead"),
+                        ("Remote", "remote"),
+                        ("Local", "local"),
+                    ),
+                ),
+                SettingFieldSpec(
+                    "select",
+                    "Planning depth",
+                    "settings-planning-depth",
+                    options=(
+                        ("Always plan", "always"),
+                        ("Multi-task only", "multi_task"),
+                        ("Never plan", "never"),
+                    ),
+                ),
+                SettingFieldSpec("switch", "Serialize manual merges", "settings-serialize-merges"),
+                SettingFieldSpec("switch", "Auto init git repo", "settings-auto-init-repo"),
+                SettingFieldSpec(
+                    "switch", "Auto create initial commit", "settings-auto-init-commit"
+                ),
+                SettingFieldSpec(
+                    "select",
+                    "Interactive launcher",
+                    "settings-attached-launcher",
+                    options=(
+                        ("tmux", "tmux"),
+                        ("nvim", "nvim"),
+                        ("vscode", "vscode"),
+                        ("cursor", "cursor"),
+                        ("windsurf", "windsurf"),
+                        ("kiro", "kiro"),
+                        ("antigravity", "antigravity"),
+                    ),
+                ),
+                SettingFieldSpec(
+                    "switch", "Open last project on launch", "settings-open-last-project"
+                ),
+                SettingFieldSpec(
+                    "switch",
+                    "Skip attach instructions popup",
+                    "settings-skip-attached-instructions",
+                ),
                 SettingFieldSpec("text", "Claude default model", "settings-default-model-claude"),
                 SettingFieldSpec("text", "OpenAI default model", "settings-default-model-openai"),
             ),

--- a/src/kagan/tui/screens/task_screen.py
+++ b/src/kagan/tui/screens/task_screen.py
@@ -127,7 +127,6 @@ class TaskScreen(Screen[None]):
         self._reviewer_session_id: str | None = None
         self._pending_reviewer_session_id = False
         self._user_switched_tab = False
-        self._last_seen_status: TaskStatus | None = None
 
     @property
     def kagan_app(self) -> KaganApp:
@@ -1162,12 +1161,7 @@ class TaskScreen(Screen[None]):
     def _maybe_auto_switch_to_review(self) -> None:
         if self._user_switched_tab:
             return
-        if self._task_model is None:
-            return
-        current = self._task_model.status
-        previous = self._last_seen_status
-        self._last_seen_status = current
-        if previous is not None and previous is not current and current is TaskStatus.REVIEW:
+        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
             with contextlib.suppress(NoMatches):
                 tabs = self.query_one("#ts-tabs", TabbedContent)
                 if getattr(tabs, "active", "") != "review":
@@ -1678,22 +1672,10 @@ class TaskScreen(Screen[None]):
         return "overview"
 
     def _select_initial_tab(self) -> None:
-        if self._task_model is not None:
-            self._last_seen_status = self._task_model.status
-        tab_id = "review" if (
-            self._task_model is not None
-            and self._task_model.status is TaskStatus.REVIEW
-        ) else "overview"
-        with contextlib.suppress(NoMatches):
-            tabs = self.query_one("#ts-tabs", TabbedContent)
-            tabs.active = tab_id
-            self.call_after_refresh(lambda: self._ensure_tab(tab_id))
-
-    def _ensure_tab(self, tab_id: str) -> None:
-        with contextlib.suppress(NoMatches):
-            tabs = self.query_one("#ts-tabs", TabbedContent)
-            if tabs.active != tab_id:
-                tabs.active = tab_id
+        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
+            self.query_one("#ts-tabs", TabbedContent).active = "review"
+        else:
+            self.query_one("#ts-tabs", TabbedContent).active = "overview"
 
     def _configure_overlay_chat(
         self,

--- a/src/kagan/tui/screens/task_screen.py
+++ b/src/kagan/tui/screens/task_screen.py
@@ -127,6 +127,7 @@ class TaskScreen(Screen[None]):
         self._reviewer_session_id: str | None = None
         self._pending_reviewer_session_id = False
         self._user_switched_tab = False
+        self._last_seen_status: TaskStatus | None = None
 
     @property
     def kagan_app(self) -> KaganApp:
@@ -1161,7 +1162,12 @@ class TaskScreen(Screen[None]):
     def _maybe_auto_switch_to_review(self) -> None:
         if self._user_switched_tab:
             return
-        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
+        if self._task_model is None:
+            return
+        current = self._task_model.status
+        previous = self._last_seen_status
+        self._last_seen_status = current
+        if previous is not None and previous is not current and current is TaskStatus.REVIEW:
             with contextlib.suppress(NoMatches):
                 tabs = self.query_one("#ts-tabs", TabbedContent)
                 if getattr(tabs, "active", "") != "review":
@@ -1672,10 +1678,16 @@ class TaskScreen(Screen[None]):
         return "overview"
 
     def _select_initial_tab(self) -> None:
-        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
-            self.query_one("#ts-tabs", TabbedContent).active = "review"
-        else:
-            self.query_one("#ts-tabs", TabbedContent).active = "overview"
+        if self._task_model is not None:
+            self._last_seen_status = self._task_model.status
+            if self._task_model.status is TaskStatus.REVIEW:
+                self.call_after_refresh(self._set_tab, "review")
+                return
+        self.call_after_refresh(self._set_tab, "overview")
+
+    def _set_tab(self, tab_id: str) -> None:
+        with contextlib.suppress(NoMatches):
+            self.query_one("#ts-tabs", TabbedContent).active = tab_id
 
     def _configure_overlay_chat(
         self,

--- a/src/kagan/tui/screens/task_screen.py
+++ b/src/kagan/tui/screens/task_screen.py
@@ -1680,14 +1680,20 @@ class TaskScreen(Screen[None]):
     def _select_initial_tab(self) -> None:
         if self._task_model is not None:
             self._last_seen_status = self._task_model.status
-            if self._task_model.status is TaskStatus.REVIEW:
-                self.call_after_refresh(self._set_tab, "review")
-                return
-        self.call_after_refresh(self._set_tab, "overview")
-
-    def _set_tab(self, tab_id: str) -> None:
+        tab_id = "review" if (
+            self._task_model is not None
+            and self._task_model.status is TaskStatus.REVIEW
+        ) else "overview"
         with contextlib.suppress(NoMatches):
-            self.query_one("#ts-tabs", TabbedContent).active = tab_id
+            tabs = self.query_one("#ts-tabs", TabbedContent)
+            tabs.active = tab_id
+            self.call_after_refresh(lambda: self._ensure_tab(tab_id))
+
+    def _ensure_tab(self, tab_id: str) -> None:
+        with contextlib.suppress(NoMatches):
+            tabs = self.query_one("#ts-tabs", TabbedContent)
+            if tabs.active != tab_id:
+                tabs.active = tab_id
 
     def _configure_overlay_chat(
         self,

--- a/src/kagan/tui/screens/task_screen.py
+++ b/src/kagan/tui/screens/task_screen.py
@@ -126,6 +126,7 @@ class TaskScreen(Screen[None]):
         self._worker_session_id: str | None = None
         self._reviewer_session_id: str | None = None
         self._pending_reviewer_session_id = False
+        self._user_switched_tab = False
 
     @property
     def kagan_app(self) -> KaganApp:
@@ -138,12 +139,38 @@ class TaskScreen(Screen[None]):
             yield Label("Branch: -", id="ts-branch", classes="ts-branch")
             yield Label("Idle", id="ts-status", classes="ts-status")
 
-            with TabbedContent(id="ts-tabs", initial="detail"):
-                with TabPane("Detail", id="detail"):
+            with TabbedContent(id="ts-tabs", initial="overview"):
+                with TabPane("Overview", id="overview"):
                     yield TaskDetailPane(id="ts-overview-pane")
 
-                with TabPane("Diff", id="diff"):
+                with TabPane("Changes", id="changes"):
                     yield TaskDiffPane(id="ts-diff-pane")
+
+                with TabPane("Review", id="review"):
+                    with VerticalScroll(id="ts-review-scroll"):
+                        yield Static(
+                            "",
+                            id="ts-detail-stream-source",
+                            classes="ts-detail-stream-source",
+                        )
+                        yield Static("", id="ts-detail-status", classes="ts-detail-status")
+                        yield Static(
+                            "",
+                            id="ts-detail-changes-summary",
+                            classes="ts-detail-changes-summary",
+                        )
+                        yield Static("Merge Readiness", classes="ts-section-label")
+                        yield Static("", id="ts-merge-readiness", classes="ts-detail-review")
+                        yield Static("Verify Criteria", classes="ts-section-label")
+                        yield Vertical(
+                            id="ts-detail-criteria-list",
+                            classes="ts-detail-criteria-list",
+                        )
+                        yield Static(
+                            "",
+                            id="ts-detail-criteria-status",
+                            classes="ts-detail-criteria-status",
+                        )
 
             yield ChatPanel(id="ts-chat-overlay", classes="chat-overlay")
 
@@ -239,24 +266,29 @@ class TaskScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_tab_detail(self) -> None:
-        self._switch_tab("detail")
+        self._switch_tab("overview")
 
     def action_tab_diff(self) -> None:
-        self._switch_tab("diff")
+        self._switch_tab("changes")
 
     def action_tab_overview(self) -> None:
-        self.action_tab_detail()
+        self._switch_tab("overview")
 
     def action_tab_changes(self) -> None:
-        self.action_tab_diff()
+        self._switch_tab("changes")
 
-    def _switch_tab(self, tab_id: str) -> None:
+    def action_tab_review(self) -> None:
+        self._switch_tab("review")
+
+    def _switch_tab(self, tab_id: str, *, user_initiated: bool = True) -> None:
         tabs = self.query_one("#ts-tabs", TabbedContent)
         self.set_focus(None)
         tabs.active = tab_id
         self.call_after_refresh(lambda: self._focus_tab_after_switch(tab_id))
         self._sync_action_bar()
         self.refresh_bindings()
+        if user_initiated:
+            self._user_switched_tab = True
 
     def action_switch_tab(self, tab_id: str) -> None:
         self._switch_tab(tab_id)
@@ -264,16 +296,16 @@ class TaskScreen(Screen[None]):
     def on_tabbed_content_tab_activated(self) -> None:
         self._sync_action_bar()
         self.refresh_bindings()
-        if self._active_tab() == "diff":
+        if self._active_tab() == "changes":
             self._schedule_runtime_refresh()
 
     def _focus_tab_after_switch(self, tab_id: str) -> None:
-        if tab_id == "diff":
+        if tab_id == "changes":
             with contextlib.suppress(NoMatches):
                 self.set_focus(self.query_one(DiffFileTree))
                 return
 
-        if tab_id == "detail":
+        if tab_id in {"overview", "review"}:
             for node in self.query(".ts-detail-criterion"):
                 if isinstance(node, Checkbox):
                     self.set_focus(node)
@@ -292,11 +324,11 @@ class TaskScreen(Screen[None]):
                 self.action_approve()
 
         active = self._active_tab()
-        if active == "detail":
+        if active == "overview":
             if task is not None and task.status is TaskStatus.REVIEW:
                 _approve_or_merge()
                 return
-            self._switch_tab("diff")
+            self._switch_tab("changes")
             if self._running:
                 self._set_status("Running")
                 return
@@ -307,7 +339,7 @@ class TaskScreen(Screen[None]):
             await self._start_or_attach_session()
             return
 
-        if active == "diff":
+        if active in {"changes", "review"}:
             _approve_or_merge()
             return
 
@@ -1126,6 +1158,15 @@ class TaskScreen(Screen[None]):
                 exit_on_error=False,
             )
 
+    def _maybe_auto_switch_to_review(self) -> None:
+        if self._user_switched_tab:
+            return
+        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
+            with contextlib.suppress(NoMatches):
+                tabs = self.query_one("#ts-tabs", TabbedContent)
+                if getattr(tabs, "active", "") != "review":
+                    tabs.active = "review"
+
     async def _refresh_runtime_state(self) -> None:
         if self._task_id is None:
             return
@@ -1135,6 +1176,7 @@ class TaskScreen(Screen[None]):
             self._refresh_header()
             self._refresh_header_labels()
             self._sync_action_bar()
+            self._maybe_auto_switch_to_review()
             await self._load_review_context()
             await self._hydrate_workspace_panels()
 
@@ -1562,7 +1604,7 @@ class TaskScreen(Screen[None]):
         if panel.has_class("visible"):
             return
 
-        if active != "diff":
+        if active != "changes":
             return
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
@@ -1627,10 +1669,13 @@ class TaskScreen(Screen[None]):
             active = getattr(tabs, "active", "")
             if isinstance(active, str) and active:
                 return active
-        return "detail"
+        return "overview"
 
     def _select_initial_tab(self) -> None:
-        self.query_one("#ts-tabs", TabbedContent).active = "detail"
+        if self._task_model is not None and self._task_model.status is TaskStatus.REVIEW:
+            self.query_one("#ts-tabs", TabbedContent).active = "review"
+        else:
+            self.query_one("#ts-tabs", TabbedContent).active = "overview"
 
     def _configure_overlay_chat(
         self,

--- a/src/kagan/tui/widgets/card.py
+++ b/src/kagan/tui/widgets/card.py
@@ -90,6 +90,10 @@ class TaskCard(Widget):
     DEFAULT_CSS = """
     TaskCard {
         layout: vertical;
+        height: 3;
+    }
+
+    TaskCard.-selected {
         height: 4;
     }
 
@@ -168,6 +172,9 @@ class TaskCard(Widget):
         self._pr_label: Static | None = None
         self._type_label: Static | None = None
         self._priority_label: Static | None = None
+        # Row container refs — toggled for compact/expanded layout.
+        self._desc_row: Horizontal | None = None
+        self._badge_row: Horizontal | None = None
         # Set reactive after super().__init__ so id is assigned.
         self.task_data = task
         self.selected = selected
@@ -285,6 +292,11 @@ class TaskCard(Widget):
             "", classes="card-badge card-badge-priority task-card-badge-priority"
         )
 
+        self._desc_row = Horizontal(classes="card-row task-card-row")
+        self._badge_row = Horizontal(
+            classes="card-row task-card-row card-badge-row task-card-badge-row"
+        )
+
         with Vertical(classes="card-content task-card-content"):
             with Horizontal(classes="card-row task-card-row"):
                 yield self._rail_label
@@ -292,14 +304,14 @@ class TaskCard(Widget):
                 yield self._title_label
                 yield self._id_label
 
-            with Horizontal(classes="card-row task-card-row"):
+            with self._desc_row:
                 yield self._desc_label
                 yield self._elapsed_label
 
             with Horizontal(classes="card-row task-card-row"):
                 yield self._status_label
 
-            with Horizontal(classes="card-row task-card-row card-badge-row task-card-badge-row"):
+            with self._badge_row:
                 yield self._backend_label
                 yield self._branch_label
                 yield self._issue_label
@@ -328,7 +340,12 @@ class TaskCard(Widget):
     # ------------------------------------------------------------------
 
     def _labels_ready(self) -> bool:
-        return self._title_label is not None and self._desc_label is not None
+        return (
+            self._title_label is not None
+            and self._desc_label is not None
+            and self._desc_row is not None
+            and self._badge_row is not None
+        )
 
     def _render_task(self) -> None:
         task = self.task_data
@@ -348,6 +365,12 @@ class TaskCard(Widget):
         assert self._pr_label is not None
         assert self._type_label is not None
         assert self._priority_label is not None
+        assert self._desc_row is not None
+        assert self._badge_row is not None
+
+        # Compact vs expanded row visibility
+        self._desc_row.display = self.selected
+        self._badge_row.display = self.selected
 
         # Title
         self._title_label.update(_truncate_text(task.title, _TITLE_MAX))
@@ -367,7 +390,9 @@ class TaskCard(Widget):
             self._indicator_label.remove_class(cls)
         self._indicator_label.add_class(indicator_css)
 
-        # Description
+        elapsed = self._format_elapsed(getattr(task, "updated_at", None))
+
+        # Description row — only shown when selected
         desc = (task.description or "").strip()
         if self.selected and desc:
             self._desc_label.update(_truncate_text(desc, _DESC_MAX))
@@ -377,17 +402,22 @@ class TaskCard(Widget):
             self._desc_label.update("")
             self._desc_label.display = False
 
-        # Elapsed
-        elapsed = self._format_elapsed(getattr(task, "updated_at", None))
-        if elapsed:
-            self._elapsed_label.update(elapsed)
-            self._elapsed_label.display = True
+        # Elapsed — on desc row when selected, appended to status row when unselected
+        if self.selected:
+            if elapsed:
+                self._elapsed_label.update(elapsed)
+                self._elapsed_label.display = True
+            else:
+                self._elapsed_label.update("")
+                self._elapsed_label.display = False
         else:
             self._elapsed_label.update("")
             self._elapsed_label.display = False
 
-        # Status line
+        # Status line — when unselected, append elapsed inline
         status_text, status_css = self._status_line(task)
+        if not self.selected and elapsed:
+            status_text = f"{status_text}  {elapsed}"
         self._status_label.update(status_text)
         for cls in _STATUS_CLASSES:
             self._status_label.remove_class(cls)
@@ -409,22 +439,29 @@ class TaskCard(Widget):
         self._pr_label.update("")
         self._pr_label.display = False
 
-        # Type
+        # Type badge — only shown when selected
         task_type = str(getattr(getattr(task, "task_type", None), "value", "")).strip()
-        if task_type:
+        if self.selected and task_type:
             self._type_label.update(task_type)
             self._type_label.display = True
         else:
             self._type_label.update("")
             self._type_label.display = False
 
-        # Priority
+        # Priority badge — only shown when selected
         priority = _priority_label(task.priority)
         priority_css = self._priority_css(task.priority)
-        self._priority_label.update(priority)
-        for cls in _PRIORITY_CLASSES:
-            self._priority_label.remove_class(cls)
-        self._priority_label.add_class(priority_css)
+        if self.selected:
+            self._priority_label.update(priority)
+            for cls in _PRIORITY_CLASSES:
+                self._priority_label.remove_class(cls)
+            self._priority_label.add_class(priority_css)
+            self._priority_label.display = True
+        else:
+            self._priority_label.update("")
+            for cls in _PRIORITY_CLASSES:
+                self._priority_label.remove_class(cls)
+            self._priority_label.display = False
 
     # ------------------------------------------------------------------
     # Events

--- a/src/kagan/tui/widgets/task_action_bar.py
+++ b/src/kagan/tui/widgets/task_action_bar.py
@@ -11,7 +11,7 @@ from kagan.tui.widgets.hint_bar import action_hints_from_bindings, format_hint
 
 
 class TaskActionBar(Widget):
-    active_tab: reactive[str] = reactive("detail")
+    active_tab: reactive[str] = reactive("overview")
     task_data: reactive[Task | None] = reactive(None)
     task_running: reactive[bool] = reactive(False)
     has_criteria: reactive[bool] = reactive(False)
@@ -55,7 +55,7 @@ class TaskActionBar(Widget):
         active = self.active_tab
         task = self.task_data
         b = TASK_SCREEN_BINDINGS
-        tabs_hint: tuple[str, str] = ("1-2", "tabs")
+        tabs_hint: tuple[str, str] = ("1-3", "tabs")
         shared_specs: list[tuple[str | tuple[str, ...], str]] = [
             ("switch_session", "sessions"),
         ]
@@ -71,11 +71,11 @@ class TaskActionBar(Widget):
             shared_specs = [("toggle_chat", "split"), *shared_specs]
             esc = action_hints_from_bindings(b, [("back", "back")])
 
-        if active == "detail":
+        if active == "overview":
             self._sync_detail_hints(hint, task, b, tabs_hint, shared_specs, esc)
             return
 
-        if active == "diff":
+        if active == "changes":
             nav_hints: list[tuple[str, str]] = [
                 tabs_hint,
                 ("j/k", "navigate"),
@@ -91,6 +91,10 @@ class TaskActionBar(Widget):
                     ]
                 ),
             )
+            return
+
+        if active == "review":
+            self._sync_detail_hints(hint, task, b, tabs_hint, shared_specs, esc)
             return
 
         self._update_hint_text(

--- a/src/kagan/tui/widgets/task_detail_pane.py
+++ b/src/kagan/tui/widgets/task_detail_pane.py
@@ -41,22 +41,6 @@ class TaskDetailPane(Widget):
                 yield Static("", id="ts-overview-base-branch", classes="ts-detail-meta")
                 yield Static("", id="ts-overview-agent-backend", classes="ts-detail-meta")
 
-            with Vertical(id="ts-detail-review-section"):
-                yield Static("Review", classes="ts-section-label")
-                yield Static("", id="ts-merge-readiness", classes="ts-detail-review")
-
-                yield Static("Verify Criteria", classes="ts-section-label")
-                yield Vertical(id="ts-detail-criteria-list", classes="ts-detail-criteria-list")
-                yield Static(
-                    "", id="ts-detail-criteria-status", classes="ts-detail-criteria-status"
-                )
-
-                yield Static("", id="ts-detail-stream-source", classes="ts-detail-stream-source")
-                yield Static("", id="ts-detail-status", classes="ts-detail-status")
-                yield Static(
-                    "", id="ts-detail-changes-summary", classes="ts-detail-changes-summary"
-                )
-
     def watch_task_data(self, task: Task | None) -> None:
         self._render_overview(task)
 
@@ -79,7 +63,6 @@ class TaskDetailPane(Widget):
 
         self.query_one("#ts-overview-base-branch", Static).update("Base branch: repo default")
         self.query_one("#ts-overview-agent-backend", Static).update("Agent: project default")
-        self._set_review_section_visible(False)
         self._hide_resume_context()
 
     def _render_task(self, task: Task) -> None:
@@ -117,13 +100,6 @@ class TaskDetailPane(Widget):
         self.query_one("#ts-overview-agent-backend", Static).update(
             f"Agent: {task.agent_backend or 'project default'}"
         )
-        has_verdicts = bool(task.review_verdicts)
-        self._set_review_section_visible(
-            task.status is TaskStatus.REVIEW or (task.status is TaskStatus.DONE and has_verdicts)
-        )
-
-    def _set_review_section_visible(self, is_visible: bool) -> None:
-        self.query_one("#ts-detail-review-section", Vertical).display = is_visible
 
     def _hide_resume_context(self) -> None:
         container = self.query_one("#ts-resume-context-section", Vertical)

--- a/src/kagan/tui/widgets/task_workspace_helpers.py
+++ b/src/kagan/tui/widgets/task_workspace_helpers.py
@@ -150,7 +150,7 @@ async def hydrate_workspace_panels(
         no_workspace=False,
     )
 
-    if active_tab == "diff":
+    if active_tab == "changes":
         selected_path = diff_view.current_file_path()
         diff_pane.update_diff(diff_text)
         if selected_path is not None and selected_path in files:

--- a/tests/tui/test_task_output.py
+++ b/tests/tui/test_task_output.py
@@ -49,7 +49,7 @@ async def test_enter_on_detached_task_opens_task_screen(board_with_task: KaganDr
         await _open_task_screen(pilot)
         assert app.screen.id == "task-screen"
         tabs = app.screen.query_one("#ts-tabs", TabbedContent)
-        assert tabs.active == "detail"
+        assert tabs.active == "overview"
 
 
 async def test_task_screen_shows_action_hint_footer(board_with_task: KaganDriver) -> None:
@@ -221,12 +221,12 @@ async def test_tab_switch_does_not_revert_to_previous_tab(board_with_task: Kagan
         tree.focus()
         await pilot.pause()
 
-        cast("TaskScreen", app.screen).action_switch_tab("detail")
+        cast("TaskScreen", app.screen).action_switch_tab("overview")
         await pilot.pause()
         await pilot.pause()
 
         tabs = app.screen.query_one("#ts-tabs", TabbedContent)
-        assert tabs.active == "detail"
+        assert tabs.active == "overview"
 
 
 async def test_task_chat_restart_failure_surfaces_error_state(

--- a/tests/tui/test_task_screen_review_no_criteria.py
+++ b/tests/tui/test_task_screen_review_no_criteria.py
@@ -140,7 +140,7 @@ async def test_enter_on_detail_tab_does_not_switch_tab(review_board: KaganDriver
         task_screen = next((s for s in reversed(screen_stack) if isinstance(s, TaskScreen)), None)
         if task_screen is not None:
             tabs = task_screen.query_one("#ts-tabs", TabbedContent)
-            assert tabs.active == "detail"
+            assert tabs.active == "review"
 
         # Top of stack should be the no-criteria modal
         assert isinstance(app.screen, ReviewNoCriteriaModal)

--- a/tests/tui/test_task_screen_review_no_criteria.py
+++ b/tests/tui/test_task_screen_review_no_criteria.py
@@ -128,12 +128,14 @@ async def test_enter_on_detail_tab_does_not_switch_tab(review_board: KaganDriver
     async with app.run_test() as pilot:
         await pilot.pause()
         app.push_screen(TaskScreen(task_id=task.id))
-        # Wait for async on_mount to complete and select initial tab
-        for _ in range(10):
+        # Wait for async on_mount + call_after_refresh to select review tab
+        for _ in range(20):
             await pilot.pause()
             ts = next((s for s in reversed(app.screen_stack) if isinstance(s, TaskScreen)), None)
             if ts is not None and ts._task_model is not None:
-                break
+                tabs = ts.query_one("#ts-tabs", TabbedContent)
+                if tabs.active == "review":
+                    break
 
         # Press Enter (primary_action) — should trigger approve flow, not switch tab
         await pilot.press("enter")

--- a/tests/tui/test_task_screen_review_no_criteria.py
+++ b/tests/tui/test_task_screen_review_no_criteria.py
@@ -128,8 +128,12 @@ async def test_enter_on_detail_tab_does_not_switch_tab(review_board: KaganDriver
     async with app.run_test() as pilot:
         await pilot.pause()
         app.push_screen(TaskScreen(task_id=task.id))
-        await pilot.pause()
-        await pilot.pause()
+        # Wait for async on_mount to complete and select initial tab
+        for _ in range(10):
+            await pilot.pause()
+            ts = next((s for s in reversed(app.screen_stack) if isinstance(s, TaskScreen)), None)
+            if ts is not None and ts._task_model is not None:
+                break
 
         # Press Enter (primary_action) — should trigger approve flow, not switch tab
         await pilot.press("enter")

--- a/tests/tui/test_task_screen_review_no_criteria.py
+++ b/tests/tui/test_task_screen_review_no_criteria.py
@@ -128,11 +128,10 @@ async def test_enter_on_detail_tab_does_not_switch_tab(review_board: KaganDriver
     async with app.run_test() as pilot:
         await pilot.pause()
         app.push_screen(TaskScreen(task_id=task.id))
-        # Wait for async on_mount + call_after_refresh to select review tab
-        for _ in range(20):
+        for _ in range(10):
             await pilot.pause()
             ts = next((s for s in reversed(app.screen_stack) if isinstance(s, TaskScreen)), None)
-            if ts is not None and ts._task_model is not None:
+            if ts is not None:
                 tabs = ts.query_one("#ts-tabs", TabbedContent)
                 if tabs.active == "review":
                     break

--- a/tests/tui/test_task_screen_review_status.py
+++ b/tests/tui/test_task_screen_review_status.py
@@ -64,7 +64,7 @@ async def test_review_stream_source_prefers_reviewer_for_review_tasks(board: Kag
         tabs = app.screen.query_one("#ts-tabs", TabbedContent)
         source = str(app.screen.query_one("#ts-detail-stream-source", Static).content)
 
-        assert tabs.active == "detail"
+        assert tabs.active == "review"
         assert "Stream: AI REVIEWER" in source
 
 
@@ -87,7 +87,7 @@ async def test_overview_hints_surface_review_actions_for_review_tasks(board: Kag
 
         hint_text = str(app.screen.query_one("#ts-action-hint", Static).content).lower()
 
-        assert "1-2" in hint_text
+        assert "1-3" in hint_text
         assert "approve" in hint_text
         assert "reject" in hint_text
 

--- a/tests/tui/test_task_screen_review_status.py
+++ b/tests/tui/test_task_screen_review_status.py
@@ -60,6 +60,7 @@ async def test_review_stream_source_prefers_reviewer_for_review_tasks(board: Kag
         app.push_screen(TaskScreen(task_id=task.id))
         await pilot.pause()
         await pilot.pause()
+        await pilot.pause()
 
         tabs = app.screen.query_one("#ts-tabs", TabbedContent)
         source = str(app.screen.query_one("#ts-detail-stream-source", Static).content)

--- a/tests/tui/test_task_screen_review_status.py
+++ b/tests/tui/test_task_screen_review_status.py
@@ -58,11 +58,12 @@ async def test_review_stream_source_prefers_reviewer_for_review_tasks(board: Kag
         await pilot.pause()
 
         app.push_screen(TaskScreen(task_id=task.id))
-        await pilot.pause()
-        await pilot.pause()
-        await pilot.pause()
+        for _ in range(10):
+            await pilot.pause()
+            tabs = app.screen.query_one("#ts-tabs", TabbedContent)
+            if tabs.active == "review":
+                break
 
-        tabs = app.screen.query_one("#ts-tabs", TabbedContent)
         source = str(app.screen.query_one("#ts-detail-stream-source", Static).content)
 
         assert tabs.active == "review"


### PR DESCRIPTION
## Summary

- **CLI**: sparse default banner on bare `kagan`, richer `--help` with docs link
- **Core**: agent backend runtime detection (`shutil.which` + `lru_cache`), transition target helpers
- **Web**: drag-drop dims invalid columns and highlights valid targets during drag
- **TUI/Web**: settings collapsed from 9/5 categories → 4 (Essentials, Workflow, Git, Advanced)
- **TUI/Web**: task cards show compact view by default, expand on selection/hover
- **Web**: command palette gains `task.*`/`agent.*`/`review.*` commands matching TUI's 18-command palette
- **TUI/Web**: agent picker groups backends by availability (installed first, unavailable dimmed)
- **API**: `/chat/agents` returns per-backend `available` field
- **TUI**: task screen tabs aligned with web (Overview / Changes / Review)

## Test plan

- [x] `ruff check` — all passed
- [x] `pyrefly` — 0 errors
- [x] `pytest` (non-snapshot) — 745 passed
- [x] `vitest` — 149 passed
- [x] `pnpm build` — clean
- [x] `check-guardrails` — LOC budget + complexity + wire drift all pass
- [ ] `poe snapshot-update` — TUI snapshots need updating (card height + tab rename)
- [ ] Manual: drag a BACKLOG task → only IN_PROGRESS column highlights
- [ ] Manual: Cmd+K shows task.*/agent.*/review.* commands
- [ ] Manual: settings panel shows 4 categories with collapsible Advanced


🤖 Generated with [Claude Code](https://claude.com/claude-code)