### PR TITLE
fix(deps): pin httpx to stable versions <1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "alembic>=1.16.0",
   "click>=8.1.0",
   "cryptography>=46.0",
+  "httpx>=0.27.1,<1.0.0",
   "loguru>=0.7.0",
   "mcp>=1.26.0,<2.0.0",
   "mslex>=1.3.0",


### PR DESCRIPTION
## Problem
httpx 1.0.dev3 (pre-release) breaks httpx-sse 0.4.3 used by MCP.
The `TransportError` class was removed in httpx 1.x causing:
```
AttributeError: module 'httpx' has no attribute 'TransportError'
```

## Solution
Pin httpx to stable 0.x versions (>=0.27.1,<1.0.0) to ensure compatibility with MCP and other dependencies.

## Impact
Fixes production deployment issue where fresh uv tool installs get incompatible pre-release httpx version, breaking MCP functionality.

## Testing
- [x] Fresh install with pinned version works correctly
- [x] MCP protocol initializes without errors
- [x] Server starts and serves API correctly

---
E2E Report: Related to production readiness testing